### PR TITLE
Add MiniMax Code Harbor evaluation profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+__pycache__/
+*.py[cod]
 
 # Local output from skills/frontierharness-eval
 runs/

--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ Cost is compared on `effective_cost_per_pass`, which is total cost across all ta
 
 Metric definitions and the trial record contract are in [`SKILL.md`](skills/frontierharness-eval/SKILL.md). Runner templates, the alternative Harbor-with-Runta-provider topology, and troubleshooting are in [`reference.md`](skills/frontierharness-eval/reference.md).
 
+MiniMax Code is available through Harbor's built-in `mcode` adapter. Its profile pins
+Harbor, Node, `@minimax-ai/code`, and both task sources; runs all 30 published task IDs
+through Harbor; and handles offline agent setup plus provider-specific connection
+mapping:
+
+```bash
+$FH/run-minimax-code.sh --provider fireworks --print-command
+```
+
+See the [MiniMax Code profile](skills/frontierharness-eval/minimax-code.md) for the
+golden-checkpoint, smoke-test, and full-run commands.
+
 ## Methodology
 
 ### Tested harness configurations

--- a/skills/frontierharness-eval/SKILL.md
+++ b/skills/frontierharness-eval/SKILL.md
@@ -27,8 +27,10 @@ address the skill's scripts through an explicit variable rather than a bare `scr
 FH=skills/frontierharness-eval/scripts
 ```
 
-Collect from the user before starting: harness name and version, the GitHub repo and
-commit for the harness under evaluation, and the task subset.
+Collect from the user before starting: harness name and version, the task subset, and
+the GitHub repo and commit when the harness is installed from source. Runner-built-in
+harnesses can instead pin their package and runner versions; see the MiniMax Code
+profile below for a concrete example.
 
 **The model is not a variable; the provider is.** FrontierHarness holds the model
 constant at **Kimi K3** so the harness is the only thing that differs. Which provider
@@ -56,7 +58,7 @@ Copy this checklist into your working notes and keep it updated:
 
 ```
 - [ ] 1. Clean runtime created
-- [ ] 2. Harness repo cloned at a pinned commit
+- [ ] 2. Harness source commit or package version pinned
 - [ ] 3. Benchmark stack installed and frozen as a golden checkpoint
 - [ ] 4. Trials run from fresh restores, trajectories saved
 - [ ] 5. Comparison diagram generated
@@ -90,6 +92,8 @@ What the script does, and why each part matters:
   pre-installed and nothing competes with the harness under test.
 - **Repo pinned by commit.** The harness is cloned to `/work/harness` at `--commit`.
   A branch name is not reproducible; always pin a SHA.
+- **Built-in harnesses pinned by version.** If the runner owns the adapter, omit
+  `--repo` and `--commit`, then pass `--harness-version` and `--harbor-version`.
 - **Benchmark stack.** Installs `uv`, `harbor` for Terminal-Bench, `pier` plus the
   `deep-swe` task corpus for DeepSWE, and `runta-sdk[harbor]`.
 - **Credential as a secret stub.** The provider key named by `--secret-name` (defaulted
@@ -156,7 +160,8 @@ If a trial dies on infrastructure rather than the task, mark it and rerun it rat
 than scoring it as a failure:
 
 ```bash
-# Re-running an existing --run-id only replaces the tasks listed, leaving the rest.
+# Re-running an existing --run-id with the same configuration only replaces the tasks
+# listed, leaving the rest. Use a new run ID when checkpoint/provider/model changes.
 echo "terminal-bench/<task>" > retry.txt
 $FH/run-trials.sh --checkpoint fh-golden-myharness-v1 --harness my-harness \
   --run-id 2026-09-02-myharness --tasks retry.txt --out runs
@@ -242,5 +247,6 @@ values.
 ## Additional resources
 
 - Command reference, runner templates, and troubleshooting: [reference.md](reference.md)
+- MiniMax Code through Harbor: [minimax-code.md](minimax-code.md)
 - Published results and task definitions: `results/eval-data.json`, `tasks/<task>/task.toml`
 - Source evaluation: <https://frontierharness.org/>

--- a/skills/frontierharness-eval/agents/frontierharness_mcode.py
+++ b/skills/frontierharness-eval/agents/frontierharness_mcode.py
@@ -1,0 +1,76 @@
+"""Harbor's MCode adapter with a checkpointed, offline installation step."""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+from pathlib import Path
+from typing import Any, override
+
+from harbor.agents.installed.mcode import MCode
+from harbor.environments.base import BaseEnvironment
+
+
+class OfflineMCode(MCode):
+    """Install a prebuilt MCode runtime without giving task setup network access."""
+
+    def __init__(
+        self,
+        *args: Any,
+        bundle_path: str = "/work/mcode-runtime.tar.gz",
+        bundle_sha256: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._bundle_path = Path(bundle_path)
+        self._bundle_sha256 = bundle_sha256
+        if bundle_sha256 and (
+            len(bundle_sha256) != 64
+            or any(character not in "0123456789abcdef" for character in bundle_sha256)
+        ):
+            raise ValueError("bundle_sha256 must be a lowercase SHA-256 digest")
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def _sha256(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @override
+    async def install(self, environment: BaseEnvironment) -> None:
+        if not self._bundle_path.is_file():
+            raise FileNotFoundError(f"MCode runtime bundle not found: {self._bundle_path}")
+        actual_sha256 = self._sha256(self._bundle_path)
+        if self._bundle_sha256 and actual_sha256 != self._bundle_sha256:
+            raise ValueError(
+                "MCode runtime bundle digest mismatch: "
+                f"expected {self._bundle_sha256}, got {actual_sha256}"
+            )
+
+        remote_bundle = "/tmp/frontierharness-mcode-runtime.tar.gz"
+        await environment.upload_file(self._bundle_path, remote_bundle)
+        quoted_bundle = shlex.quote(remote_bundle)
+        remote_digest_check = (
+            "printf '%s  %s\\n' "
+            f"{shlex.quote(actual_sha256)} {quoted_bundle} | sha256sum -c -; "
+        )
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                "command -v sha256sum >/dev/null; command -v tar >/dev/null; "
+                f"{remote_digest_check}"
+                'install_dir="$HOME/.local/mcode"; '
+                'rm -rf "$install_dir"; '
+                'mkdir -p "$install_dir" "$HOME/.nvm"; '
+                f"tar -xzf {quoted_bundle} -C \"$install_dir\"; "
+                "printf '%s\\n' "
+                "'export NVM_DIR=\"$HOME/.nvm\"' "
+                "'export PATH=\"$HOME/.local/mcode/bin:$PATH\"' "
+                '> "$HOME/.nvm/nvm.sh"; '
+                '. "$HOME/.nvm/nvm.sh"; '
+                "node --version; mcode --version"
+            ),
+        )

--- a/skills/frontierharness-eval/minimax-code.md
+++ b/skills/frontierharness-eval/minimax-code.md
@@ -1,0 +1,131 @@
+# MiniMax Code through Harbor
+
+Use this profile when the harness under evaluation is
+[MiniMax Code](https://github.com/MiniMax-AI/minimax-code). It reuses Harbor's MCode
+adapter and replaces only its networked install step with a checkpointed bundle. This
+keeps setup functional for no-network tasks without opening npm or Node download hosts
+to the agent or verifier phases.
+
+| Component | Pinned version |
+| --- | --- |
+| Harbor | `0.22.0` |
+| Node.js | `22.23.2` |
+| `@minimax-ai/code` | `0.2.7` |
+| Harbor adapter | `mcode` via `OfflineMCode` |
+| Terminal-Bench 2.1 | `sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a` |
+
+Run these commands from the repository root:
+
+```bash
+FH=skills/frontierharness-eval/scripts
+export RUNTA_TOKEN=rt_...
+export FIREWORKS_API_KEY=...  # or the key selected with --provider
+```
+
+## Provision the golden checkpoint
+
+The public `tasks/` directory identifies the 21 Terminal-Bench tasks and the nine
+DeepSWE-derived tasks. Copy it into the checkpoint to preserve a digest of the
+published definitions. The provisioner downloads Terminal-Bench from the content
+digest above and clones DeepSWE at the commit below, retains the complete environment
+and verifier assets, then overlays all 30 matching `task.toml` and `instruction.md`
+files from this repository:
+
+```bash
+$FH/provision-golden-checkpoint.sh \
+  --runtime fh-build-mcode \
+  --checkpoint fh-golden-mcode-0.2.7 \
+  --harness mcode \
+  --harness-version 0.2.7 \
+  --harbor-version 0.22.0 \
+  --harbor-only \
+  --provider fireworks \
+  --copy-tasks tasks \
+  --prepull-tasks tasks \
+  --deep-swe-ref 435ee89ec2f2e2289f33b0da4f992f0b7b7266b9 \
+  --cpus 4 --memory 8192
+```
+
+The manifest records the versions, source refs, overlay counts, copied-definition
+digest, and the generated MCode bundle digest. During provisioning, Node and the pinned
+npm package are downloaded once into an x86_64 Linux bundle. Each task setup then
+uploads that bundle and verifies its checkpointed SHA-256 before using Harbor's normal
+MCode configuration and execution paths. `--repo` and `--commit` are intentionally
+omitted because the evaluated adapter is part of the pinned Harbor release.
+
+Before running trials, verify that the manifest has `task_count: 30`,
+`terminal_bench_overlay_count: 21`, and `deep_swe_overlay_count: 9`, plus non-empty
+`tasks_sha256` and `mcode_bundle_sha256` values. Any other value means provisioning did
+not reproduce the published task set.
+
+## Smoke-test the integration
+
+Render the command first. This does not need credentials or a runtime:
+
+```bash
+$FH/run-minimax-code.sh --provider fireworks --print-command
+```
+
+Then run one task from a fresh restore before spending a full sweep:
+
+```bash
+printf '%s\n' terminal-bench/regex-log > tasks-mcode-smoke.txt
+
+$FH/run-minimax-code.sh \
+  --checkpoint fh-golden-mcode-0.2.7 \
+  --provider fireworks \
+  --run-id mcode-0.2.7-smoke \
+  --tasks tasks-mcode-smoke.txt
+```
+
+Confirm that the collected Harbor job reports `agent_info.name` as `mcode`,
+`agent_info.version` as `0.2.7`, and contains `mcode.jsonl` before starting the full
+run. A model response without a verifier result is not a successful smoke test.
+
+## Run the published task set
+
+```bash
+jq -r '.harnesses[0].task_details[].id' results/eval-data.json > tasks-mcode.txt
+
+$FH/run-minimax-code.sh \
+  --checkpoint fh-golden-mcode-0.2.7 \
+  --provider fireworks \
+  --run-id "$(date +%Y-%m-%d)-mcode-0.2.7" \
+  --tasks tasks-mcode.txt
+```
+
+`run-minimax-code.sh` delegates restore, evidence collection, and retry semantics to
+`run-trials.sh`, but replaces both suite defaults with Harbor commands over the two
+checkpointed local task directories. It uses `OfflineMCode`, a thin subclass of
+Harbor's adapter that changes only installation. The provider hostname passed with
+`--allow-agent-host` opens egress during `agent.run()` while setup and verification
+retain the task's baseline network policy.
+
+## Provider mapping
+
+MiniMax Code registers a custom BYOK provider from Harbor's model connection. The
+profile supplies `api_format=openai-completions` and translates provider routes where
+the endpoint is otherwise unavailable to the adapter:
+
+| `--provider` | MCode model | Connection behavior |
+| --- | --- | --- |
+| `fireworks` | `openai/accounts/fireworks/models/kimi-k3` | Maps `FIREWORKS_API_KEY` to the OpenAI-compatible Fireworks endpoint |
+| `moonshot` | `openai/kimi-k3` | Maps `MOONSHOT_API_KEY` to Moonshot's global endpoint |
+| `openrouter` | `openrouter/moonshotai/kimi-k3` | Uses Harbor's native OpenRouter connection |
+| `together` | `together/moonshotai/Kimi-K3` | Uses Harbor's native Together connection |
+
+The route translation changes only the client protocol. The evaluated model remains
+Kimi K3. `custom` is not accepted by this profile because it cannot safely infer a base
+URL, secret alias, API format, and egress host; use `run-trials.sh --cmd` explicitly for
+a private gateway.
+
+Harbor disables MCode's login-backed native `web_search` for BYOK runs, retains local
+`web_fetch`, and forwards task MCP servers. This prevents benchmark behavior from
+depending on accidental MiniMax account login state.
+
+## Result caveat
+
+MCode's JSONL stream exposes input, cache-read, and output token counts, which Harbor
+collects into the agent context. It does not expose provider cost, so cost fields remain
+empty unless they are joined from provider billing data. Do not substitute an estimate
+silently; state the source and method if cost is added before normalization.

--- a/skills/frontierharness-eval/reference.md
+++ b/skills/frontierharness-eval/reference.md
@@ -83,13 +83,14 @@ so a provider swap can shift cache hit rate even at identical prices.
 
 ## Runner templates
 
-`run-trials.sh` picks a template from the task id prefix. Override with `--cmd`.
-Placeholders: `{task}`, `{suite}`, `{harness}`, `{model}`, `{jobs}`.
+`run-trials.sh` picks a template from the task id prefix. Override both suites with
+`--cmd`, or use `--terminal-cmd` and `--datacurve-cmd` independently. Placeholders:
+`{task}`, `{suite}`, `{harness}`, `{model}`, `{jobs}`.
 
 **Terminal-Bench through Harbor** (`terminal-bench/*`):
 
 ```
-harbor run -d terminal-bench/terminal-bench@4.0.0 --task-id {task} -a {harness} -m {model} --jobs-dir {jobs}
+harbor run -d terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a --include-task-name {suite}/{task} -a {harness} -m {model} --jobs-dir {jobs}
 ```
 
 **DeepSWE through Pier** (`datacurve/*`):
@@ -175,6 +176,7 @@ these fields, so any custom runner can produce them directly:
   "turns": 3,
   "cache_hit_rate_normalized": 0.521,
   "exit_code": 0,
+  "exception_info": null,
   "runtime": "fh-2026-09-02-terminal-bench-regex-log",
   "checkpoint": "fh-golden-myharness-v1"
 }
@@ -183,9 +185,9 @@ these fields, so any custom runner can produce them directly:
 `status` is one of `success`, `failure`, `timeout`, or `infra_invalid`. Only
 `infra_invalid` is excluded from scoring.
 
-Reward extraction scans the collected job directory for the first non-null
-`resolved`, `is_resolved`, `reward`, or `passed` field. If a runner reports success
-differently, the extracted value will be wrong — spot-check the first trial:
+Reward extraction accepts scalar verifier rewards plus `resolved`, `is_resolved`, or
+`passed`, and rejects results with a non-null `exception_info`. If a runner reports
+success differently, the extracted value will be wrong — spot-check the first trial:
 
 ```bash
 jq . runs/<run-id>/trials/<task>/trial.json

--- a/skills/frontierharness-eval/scripts/build-report.mjs
+++ b/skills/frontierharness-eval/scripts/build-report.mjs
@@ -130,11 +130,14 @@ ${comparison}
 | Model | \`${candidate.model ?? "unspecified"}\` |
 | Provider | ${candidate.provider ? `\`${candidate.provider}\`` : "unspecified"} |
 | Harness repo | ${manifest?.harness_repo ? `\`${manifest.harness_repo}\`` : "see manifest"} |
-| Harness commit | \`${manifest?.harness_commit ?? "unknown"}\` |
+| Harness commit | \`${manifest?.harness_commit || "unknown"}\` |
+| Harness version | \`${run.harness_version || manifest?.harness_version || "unknown"}\` |
 | Runtime | ${manifest ? `${manifest.cpus} vCPU, ${manifest.memory_mib} MiB` : "see manifest"} |
 | Harbor | \`${manifest?.harbor_version ?? "unknown"}\` |
 | Pier | \`${manifest?.pier_version ?? "unknown"}\` |
+| Terminal-Bench source | \`${manifest?.terminal_bench_dataset ?? "unknown"}\` |
 | DeepSWE corpus | \`${manifest?.deep_swe_commit ?? "unknown"}\` |
+| MCode bundle | \`${manifest?.mcode_bundle_sha256 ?? "unknown"}\` |
 | Started | ${run.started_at ?? "unknown"} |
 
 Every trial is a fresh restore of the same golden checkpoint, so all runs share an identical cold start with the same vCPU, memory, disk contents, and memory state. No formal task was executed before the checkpoint was frozen.

--- a/skills/frontierharness-eval/scripts/providers.sh
+++ b/skills/frontierharness-eval/scripts/providers.sh
@@ -7,30 +7,47 @@
 
 PROVIDER_LIST="fireworks moonshot openrouter together custom"
 
-# Sets PROVIDER_MODEL, PROVIDER_SECRET, and PROVIDER_HOST. Returns 1 on unknown input.
+# Sets the generic connection plus the MiniMax Code translation fields. Keeping these
+# together prevents a provider addition from silently working in the generic runner but
+# not in the MCode profile. Returns 1 on unknown input.
 resolve_provider() {
   case "$1" in
     fireworks)
       PROVIDER_MODEL="fireworks_ai/accounts/fireworks/models/kimi-k3"
       PROVIDER_SECRET="FIREWORKS_API_KEY"
-      PROVIDER_HOST="api.fireworks.ai" ;;
+      PROVIDER_HOST="api.fireworks.ai"
+      PROVIDER_MCODE_PREFIX="openai/"
+      PROVIDER_MCODE_STRIP="fireworks_ai/"
+      PROVIDER_MCODE_CONNECTION='OPENAI_API_KEY="$FIREWORKS_API_KEY" OPENAI_BASE_URL="https://api.fireworks.ai/inference/v1"' ;;
     moonshot)
       PROVIDER_MODEL="moonshot/kimi-k3"
       PROVIDER_SECRET="MOONSHOT_API_KEY"
-      PROVIDER_HOST="api.moonshot.ai" ;;
+      PROVIDER_HOST="api.moonshot.ai"
+      PROVIDER_MCODE_PREFIX="openai/"
+      PROVIDER_MCODE_STRIP="moonshot/"
+      PROVIDER_MCODE_CONNECTION='OPENAI_API_KEY="$MOONSHOT_API_KEY" OPENAI_BASE_URL="https://api.moonshot.ai/v1"' ;;
     openrouter)
       PROVIDER_MODEL="openrouter/moonshotai/kimi-k3"
       PROVIDER_SECRET="OPENROUTER_API_KEY"
-      PROVIDER_HOST="openrouter.ai" ;;
+      PROVIDER_HOST="openrouter.ai"
+      PROVIDER_MCODE_PREFIX=""
+      PROVIDER_MCODE_STRIP=""
+      PROVIDER_MCODE_CONNECTION="" ;;
     together)
       PROVIDER_MODEL="together_ai/moonshotai/Kimi-K3"
       PROVIDER_SECRET="TOGETHER_API_KEY"
-      PROVIDER_HOST="api.together.xyz" ;;
+      PROVIDER_HOST="api.together.xyz"
+      PROVIDER_MCODE_PREFIX="together/"
+      PROVIDER_MCODE_STRIP="together_ai/"
+      PROVIDER_MCODE_CONNECTION="" ;;
     custom)
       # Anything else: --model and --secret-name must be supplied explicitly.
       PROVIDER_MODEL=""
       PROVIDER_SECRET=""
-      PROVIDER_HOST="" ;;
+      PROVIDER_HOST=""
+      PROVIDER_MCODE_PREFIX=""
+      PROVIDER_MCODE_STRIP=""
+      PROVIDER_MCODE_CONNECTION="" ;;
     *)
       return 1 ;;
   esac

--- a/skills/frontierharness-eval/scripts/provision-golden-checkpoint.sh
+++ b/skills/frontierharness-eval/scripts/provision-golden-checkpoint.sh
@@ -13,30 +13,44 @@ PROVIDER="fireworks"
 RUNTIME=""
 CHECKPOINT=""
 HARNESS=""
+HARNESS_VERSION=""
 REPO=""
 COMMIT=""
 MODEL=""
 SECRET_NAME=""
 INSTALL_SCRIPT=""
 PREPULL_TASKS=""
+COPY_TASKS=""
+HARBOR_VERSION=""
+HARBOR_ONLY=0
 CPUS=4
 MEMORY=8192
 DEEP_SWE_REF="main"
 KEEP_RUNTIME=0
+TERMINAL_BENCH_DATASET="terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a"
+NODE_VERSION="22.23.2"
+NODE_LINUX_X64_SHA256="b294a556e639d64338823920e5866c21c02741742d2e1529ee1a225c1ec9252a"
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+MCODE_AGENT_SOURCE="$SCRIPT_DIR/../agents/frontierharness_mcode.py"
 
 usage() {
   cat <<EOF
 Usage: provision-golden-checkpoint.sh --runtime NAME --checkpoint NAME --harness NAME
-                                      --repo URL --commit SHA [options]
+                                      [--repo URL --commit SHA] [options]
 
 Required:
   --runtime NAME        Name for the build runtime (deleted unless --keep-runtime)
   --checkpoint NAME     Name for the golden checkpoint
   --harness NAME        Harness identifier used in reports, e.g. my-harness
-  --repo URL            GitHub repo of the harness under evaluation
-  --commit SHA          Commit to pin the harness to
 
 Options:
+  --harness-version VER Version of a packaged or runner-built-in harness
+  --repo URL            GitHub repo of the harness under evaluation. Must be paired
+                        with --commit; optional for a runner-built-in harness.
+  --commit SHA          Commit to pin the harness to. Must be paired with --repo.
+  --harbor-version VER  Pin Harbor instead of installing its latest release
+  --harbor-only         Skip Pier when every task uses Harbor (the DeepSWE task assets
+                        are still cloned for datacurve/* tasks)
   --provider NAME       Kimi K3 provider (default fireworks, as used by the published
                         baselines). One of: $PROVIDER_LIST
                         Each preset picks the model route and key name for you.
@@ -44,8 +58,11 @@ Options:
                         does not vary the model. Required with --provider custom.
   --secret-name NAME    Env var holding the provider key, stored as a Runta secret stub.
                         Defaults to the provider preset, required with custom.
-  --install-script PATH Local script uploaded and run inside /work/harness to build it
+  --install-script PATH Local script uploaded and run inside /work/harness (or /work
+                        for a runner-built-in harness) to build it
   --prepull-tasks DIR   Directory of <task>/task.toml files whose images are pre-pulled
+  --copy-tasks DIR      Copy public task definitions to /work/frontierharness-tasks;
+                        overlay pinned Terminal-Bench and DeepSWE task assets
   --cpus N              vCPUs (default 4)
   --memory MIB          Memory in MiB (default 8192)
   --deep-swe-ref REF    Git ref for the deep-swe corpus (default main)
@@ -58,13 +75,17 @@ while [ $# -gt 0 ]; do
     --runtime) RUNTIME=$2; shift 2 ;;
     --checkpoint) CHECKPOINT=$2; shift 2 ;;
     --harness) HARNESS=$2; shift 2 ;;
+    --harness-version) HARNESS_VERSION=$2; shift 2 ;;
     --repo) REPO=$2; shift 2 ;;
     --commit) COMMIT=$2; shift 2 ;;
+    --harbor-version) HARBOR_VERSION=$2; shift 2 ;;
+    --harbor-only) HARBOR_ONLY=1; shift ;;
     --provider) PROVIDER=$2; shift 2 ;;
     --model) MODEL=$2; shift 2 ;;
     --secret-name) SECRET_NAME=$2; shift 2 ;;
     --install-script) INSTALL_SCRIPT=$2; shift 2 ;;
     --prepull-tasks) PREPULL_TASKS=$2; shift 2 ;;
+    --copy-tasks) COPY_TASKS=$2; shift 2 ;;
     --cpus) CPUS=$2; shift 2 ;;
     --memory) MEMORY=$2; shift 2 ;;
     --deep-swe-ref) DEEP_SWE_REF=$2; shift 2 ;;
@@ -74,12 +95,49 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-for required in RUNTIME CHECKPOINT HARNESS REPO COMMIT; do
+for required in RUNTIME CHECKPOINT HARNESS; do
   if [ -z "${!required}" ]; then
     echo "missing --$(echo "$required" | tr 'A-Z_' 'a-z-')" >&2
     usage >&2
     exit 2
   fi
+done
+
+if { [ -n "$REPO" ] && [ -z "$COMMIT" ]; } || { [ -z "$REPO" ] && [ -n "$COMMIT" ]; }; then
+  echo "--repo and --commit must be supplied together" >&2
+  usage >&2
+  exit 2
+fi
+
+if [ -z "$REPO" ] && [ -z "$HARNESS_VERSION" ]; then
+  echo "runner-built-in harnesses require --harness-version" >&2
+  usage >&2
+  exit 2
+fi
+
+for version in "$HARNESS_VERSION" "$HARBOR_VERSION"; do
+  case "$version" in
+    *[!A-Za-z0-9._+-]*) echo "version values may contain only letters, digits, '.', '_', '+', and '-'" >&2; exit 2 ;;
+  esac
+done
+
+case "$DEEP_SWE_REF" in
+  ""|*[!A-Za-z0-9._/+:-]*) echo "invalid --deep-swe-ref: $DEEP_SWE_REF" >&2; exit 2 ;;
+esac
+if [ -n "$COMMIT" ]; then
+  case "$COMMIT" in
+    *[!A-Fa-f0-9]*) echo "--commit must be a hexadecimal commit SHA" >&2; exit 2 ;;
+  esac
+fi
+if [ -n "$REPO" ]; then
+  case "$REPO" in
+    *[!A-Za-z0-9._:/@+-]*) echo "invalid --repo: $REPO" >&2; exit 2 ;;
+  esac
+fi
+for value in "$RUNTIME" "$CHECKPOINT" "$HARNESS"; do
+  case "$value" in
+    *[!A-Za-z0-9._-]*) echo "runtime, checkpoint, and harness names must be path-safe" >&2; exit 2 ;;
+  esac
 done
 
 if ! resolve_provider "$PROVIDER"; then
@@ -95,6 +153,12 @@ if [ -z "$MODEL" ] || [ -z "$SECRET_NAME" ]; then
   exit 2
 fi
 warn_unless_kimi_k3 "$MODEL"
+case "$MODEL" in
+  *[!A-Za-z0-9._:/@+-]*) echo "invalid --model: $MODEL" >&2; exit 2 ;;
+esac
+case "$SECRET_NAME" in
+  ""|[0-9]*|*[!A-Za-z0-9_]*) echo "invalid --secret-name: $SECRET_NAME" >&2; exit 2 ;;
+esac
 
 : "${RUNTA_TOKEN:?RUNTA_TOKEN is not set}"
 command -v runta >/dev/null || { echo "runta CLI not found" >&2; exit 1; }
@@ -127,25 +191,73 @@ rexec 'set -eu
   command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
   mkdir -p /work/jobs /work/evidence'
 
-step "4/8 cloning $REPO at $COMMIT"
-rexec "set -eu
-  export PATH=\"\$HOME/.local/bin:\$PATH\"
-  rm -rf /work/harness
-  git clone --quiet '$REPO' /work/harness
-  cd /work/harness
-  git checkout --quiet '$COMMIT'
-  git rev-parse HEAD"
+if [ -n "$REPO" ]; then
+  step "4/8 cloning $REPO at $COMMIT"
+  rexec "set -eu
+    export PATH=\"\$HOME/.local/bin:\$PATH\"
+    rm -rf /work/harness
+    git clone --quiet '$REPO' /work/harness
+    cd /work/harness
+    git checkout --quiet '$COMMIT'
+    git rev-parse HEAD"
+else
+  step "4/8 using runner-built-in harness $HARNESS${HARNESS_VERSION:+@$HARNESS_VERSION}"
+fi
 
-step "5/8 installing Harbor, Pier, and the deep-swe corpus"
-rexec "set -eu
-  export PATH=\"\$HOME/.local/bin:\$PATH\"
-  uv tool install --quiet 'harbor[modal]' || uv tool install --quiet harbor
-  uv tool install --quiet git+https://github.com/datacurve-ai/pier
-  uv tool install --quiet --with 'runta-sdk[harbor]' harbor || true
-  rm -rf /work/deep-swe
-  git clone --quiet https://github.com/datacurve-ai/deep-swe /work/deep-swe
-  cd /work/deep-swe && git checkout --quiet '$DEEP_SWE_REF'
-  harbor --version && pier --version"
+HARBOR_PACKAGE="harbor"
+HARBOR_PACKAGE_WITH_MODAL="harbor[modal]"
+if [ -n "$HARBOR_VERSION" ]; then
+  HARBOR_PACKAGE="harbor==$HARBOR_VERSION"
+  HARBOR_PACKAGE_WITH_MODAL="harbor[modal]==$HARBOR_VERSION"
+fi
+if [ "$HARBOR_ONLY" -eq 1 ]; then
+  step "5/8 installing Harbor and the deep-swe corpus"
+  rexec "set -eu
+    export PATH=\"\$HOME/.local/bin:\$PATH\"
+    uv tool install --quiet '$HARBOR_PACKAGE'
+    rm -rf /work/deep-swe
+    git clone --quiet https://github.com/datacurve-ai/deep-swe /work/deep-swe
+    cd /work/deep-swe && git checkout --quiet '$DEEP_SWE_REF'
+    harbor --version"
+else
+  step "5/8 installing Harbor, Pier, and the deep-swe corpus"
+  rexec "set -eu
+    export PATH=\"\$HOME/.local/bin:\$PATH\"
+    uv tool install --quiet '$HARBOR_PACKAGE_WITH_MODAL' || uv tool install --quiet '$HARBOR_PACKAGE'
+    uv tool install --quiet git+https://github.com/datacurve-ai/pier
+    uv tool install --quiet --with 'runta-sdk[harbor]' '$HARBOR_PACKAGE' || true
+    rm -rf /work/deep-swe
+    git clone --quiet https://github.com/datacurve-ai/deep-swe /work/deep-swe
+    cd /work/deep-swe && git checkout --quiet '$DEEP_SWE_REF'
+    harbor --version && pier --version"
+fi
+
+if [ "$HARNESS" = mcode ]; then
+  [ -f "$MCODE_AGENT_SOURCE" ] || { echo "offline MCode agent not found: $MCODE_AGENT_SOURCE" >&2; exit 1; }
+  runta cp "$MCODE_AGENT_SOURCE" "$RUNTIME:/work/frontierharness_mcode.py"
+  rexec "set -eu
+    test \"\$(uname -m)\" = x86_64 || {
+      echo 'the pinned MCode runtime bundle currently supports x86_64 Runta runtimes only' >&2
+      exit 1
+    }
+    archive=/work/node-v$NODE_VERSION-linux-x64.tar.gz
+    curl -fsSL 'https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz' -o \"\$archive\"
+    printf '%s  %s\\n' '$NODE_LINUX_X64_SHA256' \"\$archive\" | sha256sum -c -
+    rm -rf /work/mcode-runtime /work/mcode-runtime.tar.gz
+    mkdir -p /work/mcode-runtime
+    tar -xzf \"\$archive\" -C /work/mcode-runtime --strip-components=1
+    PATH=/work/mcode-runtime/bin:\"\$PATH\" npm install --global \
+      --prefix /work/mcode-runtime --registry=https://registry.npmjs.org \
+      '@minimax-ai/code@$HARNESS_VERSION'
+    PATH=/work/mcode-runtime/bin:\"\$PATH\" mcode --version \
+      | tee /work/evidence/mcode-version
+    grep -F '$HARNESS_VERSION' /work/evidence/mcode-version >/dev/null
+    /work/mcode-runtime/bin/node --version > /work/evidence/node-version
+    tar -czf /work/mcode-runtime.tar.gz -C /work/mcode-runtime .
+    sha256sum /work/mcode-runtime.tar.gz | cut -d' ' -f1 \
+      > /work/evidence/mcode-bundle.sha256
+    rm -rf /work/mcode-runtime \"\$archive\""
+fi
 
 if [ -n "$INSTALL_SCRIPT" ]; then
   step "6/8 running harness install script"
@@ -154,12 +266,58 @@ if [ -n "$INSTALL_SCRIPT" ]; then
   rexec 'set -eu
     export PATH="$HOME/.local/bin:$PATH"
     chmod +x /work/install-harness.sh
-    cd /work/harness && /work/install-harness.sh'
+    if [ -d /work/harness ]; then cd /work/harness; else cd /work; fi
+    /work/install-harness.sh'
 else
   step "6/8 skipping harness install (no --install-script)"
 fi
 
 step "7/8 warming caches"
+# Preserve the exact public task definitions in the checkpoint. The pinned upstream
+# sources supply environment and verifier assets omitted from this results-only repo;
+# every matching task.toml and instruction.md is overlaid with the checked-in copy.
+if [ -n "$COPY_TASKS" ]; then
+  [ -d "$COPY_TASKS" ] || { echo "task directory not found: $COPY_TASKS" >&2; exit 1; }
+  rexec 'rm -rf /work/frontierharness-tasks'
+  runta cp "$COPY_TASKS" "$RUNTIME:/work/frontierharness-tasks"
+  rexec "set -eu
+    export PATH=\"\$HOME/.local/bin:\$PATH\"
+    rm -rf /work/terminal-bench-source /work/terminal-bench
+    harbor datasets download '$TERMINAL_BENCH_DATASET' \
+      --output-dir /work/terminal-bench-source --export
+    terminal_source=/work/terminal-bench-source/terminal-bench-2-1
+    test -d \"\$terminal_source\"
+    mkdir -p /work/terminal-bench/tasks
+    test -n \"\$(find /work/frontierharness-tasks -mindepth 2 -maxdepth 2 -name task.toml -print -quit)\"
+    terminal_overlaid=0
+    deep_swe_overlaid=0
+    for public_task in /work/frontierharness-tasks/*; do
+      task_name=\"\$(sed -n 's/^name = \"\\([^\"]*\\)\"/\\1/p' \"\$public_task/task.toml\" | head -1)\"
+      slug=\"\${task_name#*/}\"
+      case \"\$task_name\" in
+        terminal-bench/*)
+          source_task=\"\$terminal_source/\$slug\"
+          test -d \"\$source_task\" || { echo \"missing Terminal-Bench assets for \$task_name\" >&2; exit 1; }
+          destination=/work/terminal-bench/tasks/\"\$slug\"
+          cp -a \"\$source_task\" \"\$destination\"
+          cp \"\$public_task/task.toml\" \"\$destination/task.toml\"
+          cp \"\$public_task/instruction.md\" \"\$destination/instruction.md\"
+          terminal_overlaid=\$((terminal_overlaid + 1))
+          ;;
+        datacurve/*)
+          destination=/work/deep-swe/tasks/\"\$slug\"
+          test -d \"\$destination\" || { echo \"missing DeepSWE assets for \$task_name\" >&2; exit 1; }
+          cp \"\$public_task/task.toml\" \"\$destination/task.toml\"
+          cp \"\$public_task/instruction.md\" \"\$destination/instruction.md\"
+          deep_swe_overlaid=\$((deep_swe_overlaid + 1))
+          ;;
+        *) echo \"unsupported public task name: \$task_name\" >&2; exit 1 ;;
+      esac
+    done
+    printf '%s\\n' \"\$terminal_overlaid\" > /work/evidence/terminal-bench-overlay-count
+    printf '%s\\n' \"\$deep_swe_overlaid\" > /work/evidence/deep-swe-overlay-count
+    rm -rf /work/terminal-bench-source"
+fi
 # Pre-pull the images the formal tasks need. Pulling an image is environment prep;
 # executing a formal task before the checkpoint would be warm-cache bias.
 if [ -n "$PREPULL_TASKS" ] && [ -d "$PREPULL_TASKS" ]; then
@@ -181,22 +339,60 @@ rexec 'set -eu
 step "8/8 writing manifest and creating golden checkpoint $CHECKPOINT"
 rexec "set -eu
   export PATH=\"\$HOME/.local/bin:\$PATH\"
-  cd /work/harness
+  if [ -d /work/harness ]; then
+    harness_commit=\"\$(git -C /work/harness rev-parse HEAD)\"
+    harness_describe=\"\$(git -C /work/harness describe --tags --always 2>/dev/null || echo unknown)\"
+  else
+    harness_commit=
+    harness_describe=
+  fi
+  if [ -d /work/frontierharness-tasks ]; then
+    task_count=\"\$(find /work/frontierharness-tasks -mindepth 2 -maxdepth 2 -name task.toml | wc -l | tr -d ' ')\"
+    tasks_sha256=\"\$(find /work/frontierharness-tasks -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)\"
+    terminal_bench_overlay_count=\"\$(cat /work/evidence/terminal-bench-overlay-count 2>/dev/null || echo 0)\"
+    deep_swe_overlay_count=\"\$(cat /work/evidence/deep-swe-overlay-count 2>/dev/null || echo 0)\"
+  else
+    task_count=0
+    tasks_sha256=
+    terminal_bench_overlay_count=0
+    deep_swe_overlay_count=0
+  fi
+  if [ -d /work/terminal-bench/tasks ]; then
+    terminal_bench_tasks_sha256=\"\$(find /work/terminal-bench/tasks -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)\"
+  else
+    terminal_bench_tasks_sha256=
+  fi
+  if [ -d /work/deep-swe/tasks ]; then
+    deep_swe_tasks_sha256=\"\$(find /work/deep-swe/tasks -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)\"
+  else
+    deep_swe_tasks_sha256=
+  fi
   cat > /work/manifest.json <<MANIFEST
 {
   \"harness\": \"$HARNESS\",
+  \"harness_version\": \"$HARNESS_VERSION\",
   \"harness_repo\": \"$REPO\",
-  \"harness_commit\": \"\$(git rev-parse HEAD)\",
-  \"harness_describe\": \"\$(git describe --tags --always 2>/dev/null || echo unknown)\",
+  \"harness_commit\": \"\$harness_commit\",
+  \"harness_describe\": \"\$harness_describe\",
   \"model\": \"$MODEL\",
   \"provider\": \"$PROVIDER\",
   \"provider_host\": \"$PROVIDER_HOST\",
   \"checkpoint\": \"$CHECKPOINT\",
   \"cpus\": $CPUS,
   \"memory_mib\": $MEMORY,
-  \"deep_swe_commit\": \"\$(git -C /work/deep-swe rev-parse HEAD)\",
+  \"task_count\": \$task_count,
+  \"tasks_sha256\": \"\$tasks_sha256\",
+  \"terminal_bench_dataset\": \"$TERMINAL_BENCH_DATASET\",
+  \"terminal_bench_overlay_count\": \$terminal_bench_overlay_count,
+  \"terminal_bench_tasks_sha256\": \"\$terminal_bench_tasks_sha256\",
+  \"deep_swe_overlay_count\": \$deep_swe_overlay_count,
+  \"deep_swe_tasks_sha256\": \"\$deep_swe_tasks_sha256\",
+  \"deep_swe_commit\": \"\$(git -C /work/deep-swe rev-parse HEAD 2>/dev/null || true)\",
+  \"mcode_bundle_sha256\": \"\$(cat /work/evidence/mcode-bundle.sha256 2>/dev/null || true)\",
+  \"mcode_agent_sha256\": \"\$(sha256sum /work/frontierharness_mcode.py 2>/dev/null | cut -d' ' -f1 || true)\",
+  \"node_version\": \"\$(cat /work/evidence/node-version 2>/dev/null || true)\",
   \"harbor_version\": \"\$(harbor --version 2>&1 | head -1)\",
-  \"pier_version\": \"\$(pier --version 2>&1 | head -1)\",
+  \"pier_version\": \"\$(if command -v pier >/dev/null; then pier --version 2>&1 | head -1; fi)\",
   \"python_version\": \"\$(python3 --version 2>&1)\",
   \"created_at\": \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
 }

--- a/skills/frontierharness-eval/scripts/run-minimax-code.sh
+++ b/skills/frontierharness-eval/scripts/run-minimax-code.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Run MiniMax Code as Harbor's built-in `mcode` agent against the public task set.
+set -euo pipefail
+
+# shellcheck source=providers.sh
+. "$(cd "$(dirname "$0")" && pwd)/providers.sh"
+
+PROVIDER="fireworks"
+MODEL=""
+MCODE_VERSION="0.2.7"
+CHECKPOINT=""
+RUN_ID=""
+TASKS=""
+OUT="runs"
+TIMEOUT="5400"
+PRINT_COMMAND=0
+
+usage() {
+  cat <<EOF
+Usage: run-minimax-code.sh --checkpoint NAME --run-id ID --tasks FILE [options]
+
+Options:
+  --provider NAME      Kimi K3 provider (default fireworks). One of:
+                       fireworks moonshot openrouter together
+  --model ID           Override the provider's Kimi K3 model route
+  --out DIR            Root output directory (default runs)
+  --timeout SEC        Per-task timeout (default 5400)
+  --print-command      Print the rendered Harbor template and exit; no credentials or
+                       Runta runtime are required
+
+The golden checkpoint must contain pinned Terminal-Bench and DeepSWE assets overlaid
+with this repository's public task definitions, plus the offline MCode runtime bundle.
+Create it with provision-golden-checkpoint.sh --copy-tasks tasks. All task suites are
+then executed through Harbor.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --checkpoint) CHECKPOINT=$2; shift 2 ;;
+    --run-id) RUN_ID=$2; shift 2 ;;
+    --tasks) TASKS=$2; shift 2 ;;
+    --provider) PROVIDER=$2; shift 2 ;;
+    --model) MODEL=$2; shift 2 ;;
+    --out) OUT=$2; shift 2 ;;
+    --timeout) TIMEOUT=$2; shift 2 ;;
+    --print-command) PRINT_COMMAND=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if ! resolve_provider "$PROVIDER" || [ "$PROVIDER" = custom ]; then
+  echo "unsupported --provider $PROVIDER; expected fireworks, moonshot, openrouter, or together" >&2
+  exit 2
+fi
+MODEL=${MODEL:-$PROVIDER_MODEL}
+warn_unless_kimi_k3 "$MODEL"
+case "$MODEL" in
+  ""|*[!A-Za-z0-9._:/+-]*) echo "invalid --model: $MODEL" >&2; exit 2 ;;
+esac
+case "$TIMEOUT" in
+  ""|*[!0-9]*) echo "invalid --timeout: $TIMEOUT" >&2; exit 2 ;;
+esac
+
+# Harbor's MCode adapter registers an API-key provider in MCode. The shared provider
+# resolver owns the protocol translation so generic and MCode routes cannot drift.
+MCODE_MODEL="$PROVIDER_MCODE_PREFIX${MODEL#"$PROVIDER_MCODE_STRIP"}"
+CONNECTION=$PROVIDER_MCODE_CONNECTION
+
+COMMAND_PREFIX="env PYTHONPATH=/work${CONNECTION:+ $CONNECTION}"
+BUNDLE_SHA='$(cat /work/evidence/mcode-bundle.sha256)'
+AGENT_ARGS="-a frontierharness_mcode:OfflineMCode -m $MCODE_MODEL --ak version=$MCODE_VERSION --ak bundle_path=/work/mcode-runtime.tar.gz --ak bundle_sha256=$BUNDLE_SHA --ak api_format=openai-completions --allow-agent-host $PROVIDER_HOST --jobs-dir {jobs}"
+TERMINAL_COMMAND="$COMMAND_PREFIX harbor run -p /work/terminal-bench/tasks --include-task-name {task} $AGENT_ARGS"
+DATACURVE_COMMAND="$COMMAND_PREFIX harbor run -p /work/deep-swe/tasks --include-task-name {task} $AGENT_ARGS"
+
+if [ "$PRINT_COMMAND" -eq 1 ]; then
+  printf 'terminal-bench\t%s\n' "$TERMINAL_COMMAND"
+  printf 'datacurve\t%s\n' "$DATACURVE_COMMAND"
+  exit 0
+fi
+
+for required in CHECKPOINT RUN_ID TASKS; do
+  if [ -z "${!required}" ]; then
+    echo "missing --$(echo "$required" | tr 'A-Z_' 'a-z-')" >&2
+    usage >&2
+    exit 2
+  fi
+done
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+exec "$SCRIPT_DIR/run-trials.sh" \
+  --checkpoint "$CHECKPOINT" \
+  --harness mcode \
+  --harness-version "$MCODE_VERSION" \
+  --provider "$PROVIDER" \
+  --model "$MCODE_MODEL" \
+  --checkpoint-model "$MODEL" \
+  --run-id "$RUN_ID" \
+  --tasks "$TASKS" \
+  --out "$OUT" \
+  --timeout "$TIMEOUT" \
+  --terminal-cmd "$TERMINAL_COMMAND" \
+  --datacurve-cmd "$DATACURVE_COMMAND"

--- a/skills/frontierharness-eval/scripts/run-trials.sh
+++ b/skills/frontierharness-eval/scripts/run-trials.sh
@@ -11,30 +11,49 @@ PROVIDER="fireworks"
 
 CHECKPOINT=""
 HARNESS=""
+HARNESS_VERSION=""
 MODEL=""
+CHECKPOINT_MODEL=""
 RUN_ID=""
 TASKS=""
 OUT="runs"
 CMD_TEMPLATE=""
+TERMINAL_CMD_TEMPLATE=""
+DATACURVE_CMD_TEMPLATE=""
 TIMEOUT=5400
+MCODE_TERMINAL_BENCH_DATASET="terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a"
+MCODE_DEEP_SWE_COMMIT="435ee89ec2f2e2289f33b0da4f992f0b7b7266b9"
 
 usage() {
   cat <<EOF
 Usage: run-trials.sh --checkpoint NAME --harness NAME --run-id ID --tasks FILE
-                     [--provider NAME] [--model ID] [--out DIR] [--cmd TEMPLATE]
+                     [--harness-version VER] [--provider NAME] [--model ID]
+                     [--checkpoint-model ID]
+                     [--out DIR] [--cmd TEMPLATE]
+                     [--terminal-cmd TEMPLATE] [--datacurve-cmd TEMPLATE]
                      [--timeout SEC]
 
   --tasks FILE    One task id per line: terminal-bench/<id> or datacurve/<id>
+  --harness-version VER
+                  Exact packaged agent version executed by the runner, if applicable.
   --provider NAME Kimi K3 provider, must match the golden checkpoint's provider.
                   Default fireworks. One of: $PROVIDER_LIST
   --model ID      Override the model route. Must still be Kimi K3; the benchmark does
                   not vary the model. Required with --provider custom.
+  --checkpoint-model ID
+                  Model route recorded by the checkpoint when it differs from the
+                  agent-facing route. Defaults to --model.
   --out DIR       Root output directory (default runs)
   --cmd TEMPLATE  Override the runner command. Placeholders: {task} {suite} {harness}
                   {model} {jobs}. Default templates are per suite, see reference.md.
+  --terminal-cmd TEMPLATE
+                  Override only the terminal-bench/* runner command.
+  --datacurve-cmd TEMPLATE
+                  Override only the datacurve/* runner command.
   --timeout SEC   Per-task timeout in seconds (default 5400, matching task.toml)
 
-Re-running an existing --run-id only re-runs the listed tasks and leaves the rest.
+Re-running an existing --run-id with the same immutable configuration only re-runs the
+listed tasks and leaves the rest. Configuration changes require a new run ID.
 EOF
 }
 
@@ -42,12 +61,16 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --checkpoint) CHECKPOINT=$2; shift 2 ;;
     --harness) HARNESS=$2; shift 2 ;;
+    --harness-version) HARNESS_VERSION=$2; shift 2 ;;
     --provider) PROVIDER=$2; shift 2 ;;
     --model) MODEL=$2; shift 2 ;;
+    --checkpoint-model) CHECKPOINT_MODEL=$2; shift 2 ;;
     --run-id) RUN_ID=$2; shift 2 ;;
     --tasks) TASKS=$2; shift 2 ;;
     --out) OUT=$2; shift 2 ;;
     --cmd) CMD_TEMPLATE=$2; shift 2 ;;
+    --terminal-cmd) TERMINAL_CMD_TEMPLATE=$2; shift 2 ;;
+    --datacurve-cmd) DATACURVE_CMD_TEMPLATE=$2; shift 2 ;;
     --timeout) TIMEOUT=$2; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
@@ -71,34 +94,94 @@ if [ -z "$MODEL" ]; then
   echo "--provider custom needs --model" >&2
   exit 2
 fi
+CHECKPOINT_MODEL=${CHECKPOINT_MODEL:-$MODEL}
 warn_unless_kimi_k3 "$MODEL"
+case "$TIMEOUT" in
+  ""|*[!0-9]*) echo "invalid --timeout: $TIMEOUT" >&2; exit 2 ;;
+esac
+case "$CHECKPOINT" in
+  *[!A-Za-z0-9._-]*) echo "invalid --checkpoint: $CHECKPOINT" >&2; exit 2 ;;
+esac
+case "$RUN_ID" in
+  *[!A-Za-z0-9._-]*) echo "invalid --run-id: $RUN_ID" >&2; exit 2 ;;
+esac
+case "$HARNESS" in
+  *[!A-Za-z0-9._:/@+-]*) echo "invalid --harness: $HARNESS" >&2; exit 2 ;;
+esac
+case "$HARNESS_VERSION" in
+  *[!A-Za-z0-9._+-]*) echo "invalid --harness-version: $HARNESS_VERSION" >&2; exit 2 ;;
+esac
+case "$MODEL" in
+  *[!A-Za-z0-9._:/@+-]*) echo "invalid --model: $MODEL" >&2; exit 2 ;;
+esac
+case "$CHECKPOINT_MODEL" in
+  *[!A-Za-z0-9._:/@+-]*) echo "invalid --checkpoint-model: $CHECKPOINT_MODEL" >&2; exit 2 ;;
+esac
 
 : "${RUNTA_TOKEN:?RUNTA_TOKEN is not set}"
 command -v runta >/dev/null || { echo "runta CLI not found" >&2; exit 1; }
 command -v jq >/dev/null || { echo "jq not found" >&2; exit 1; }
 [ -r "$TASKS" ] || { echo "cannot read task list: $TASKS" >&2; exit 1; }
 
-RUN_DIR="$OUT/$RUN_ID"
-mkdir -p "$RUN_DIR/trials"
-
-jq -n --arg run_id "$RUN_ID" --arg checkpoint "$CHECKPOINT" --arg harness "$HARNESS" \
-      --arg model "$MODEL" --arg provider "$PROVIDER" \
-      --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-  '{run_id:$run_id, checkpoint:$checkpoint, harness:$harness, model:$model,
-    provider:$provider, started_at:$started}' \
-  > "$RUN_DIR/run.json"
-
 # Harbor drives Terminal-Bench tasks; Pier drives DeepSWE tasks in air-gapped mode.
 default_cmd() {
   case "$1" in
     terminal-bench)
-      echo "harbor run -d terminal-bench/terminal-bench@4.0.0 --task-id {task} -a {harness} -m {model} --jobs-dir {jobs}" ;;
+      echo "harbor run -d terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a --include-task-name {suite}/{task} -a {harness} -m {model} --jobs-dir {jobs}" ;;
     datacurve)
       echo "pier run -p /work/deep-swe/tasks/{task} --agent {harness} --model {model} --output-dir {jobs}" ;;
     *)
       echo "" ;;
   esac
 }
+
+sha256_text() {
+  if command -v sha256sum >/dev/null; then
+    printf '%s' "$1" | sha256sum | cut -d' ' -f1
+  elif command -v shasum >/dev/null; then
+    printf '%s' "$1" | shasum -a 256 | cut -d' ' -f1
+  else
+    echo "sha256sum or shasum is required to identify runner commands" >&2
+    return 1
+  fi
+}
+
+EFFECTIVE_TERMINAL_CMD=${CMD_TEMPLATE:-${TERMINAL_CMD_TEMPLATE:-$(default_cmd terminal-bench)}}
+EFFECTIVE_DATACURVE_CMD=${CMD_TEMPLATE:-${DATACURVE_CMD_TEMPLATE:-$(default_cmd datacurve)}}
+TERMINAL_CMD_SHA256=$(sha256_text "$EFFECTIVE_TERMINAL_CMD")
+DATACURVE_CMD_SHA256=$(sha256_text "$EFFECTIVE_DATACURVE_CMD")
+
+RUN_DIR="$OUT/$RUN_ID"
+mkdir -p "$RUN_DIR/trials"
+
+if [ -f "$RUN_DIR/run.json" ]; then
+  if ! jq -e --arg checkpoint "$CHECKPOINT" --arg harness "$HARNESS" \
+      --arg harness_version "$HARNESS_VERSION" --arg model "$MODEL" \
+      --arg checkpoint_model "$CHECKPOINT_MODEL" --arg provider "$PROVIDER" \
+      --arg terminal_cmd_sha256 "$TERMINAL_CMD_SHA256" \
+      --arg datacurve_cmd_sha256 "$DATACURVE_CMD_SHA256" --argjson timeout "$TIMEOUT" \
+      '.checkpoint == $checkpoint and .harness == $harness and
+       (.harness_version // "") == $harness_version and .model == $model and
+       .checkpoint_model == $checkpoint_model and .provider == $provider and
+       .timeout_seconds == $timeout and .terminal_command_sha256 == $terminal_cmd_sha256 and
+       .datacurve_command_sha256 == $datacurve_cmd_sha256' "$RUN_DIR/run.json" >/dev/null; then
+    echo "run id '$RUN_ID' already exists with a different immutable run configuration" >&2
+    exit 2
+  fi
+else
+  jq -n --arg run_id "$RUN_ID" --arg checkpoint "$CHECKPOINT" --arg harness "$HARNESS" \
+        --arg harness_version "$HARNESS_VERSION" \
+        --arg model "$MODEL" --arg checkpoint_model "$CHECKPOINT_MODEL" \
+        --arg provider "$PROVIDER" --arg terminal_cmd_sha256 "$TERMINAL_CMD_SHA256" \
+        --arg datacurve_cmd_sha256 "$DATACURVE_CMD_SHA256" --argjson timeout "$TIMEOUT" \
+        --arg started "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{run_id:$run_id, checkpoint:$checkpoint, harness:$harness,
+      harness_version:(if $harness_version == "" then null else $harness_version end),
+      model:$model, checkpoint_model:$checkpoint_model, provider:$provider,
+      timeout_seconds:$timeout, terminal_command_sha256:$terminal_cmd_sha256,
+      datacurve_command_sha256:$datacurve_cmd_sha256, started_at:$started}' \
+    > "$RUN_DIR/run.json"
+fi
 
 render() {
   echo "$1" \
@@ -128,11 +211,22 @@ while IFS= read -r entry || [ -n "$entry" ]; do
 
   suite=${entry%%/*}
   task=${entry#*/}
+  case "$suite" in
+    terminal-bench|datacurve) ;;
+    *) echo "unsupported task suite in '$entry'" >&2; exit 2 ;;
+  esac
+  case "$task" in
+    ""|*[!A-Za-z0-9._+-]*) echo "invalid task id in '$entry'" >&2; exit 2 ;;
+  esac
   slug=$(echo "$entry" | tr '/' '-')
   trial_dir="$RUN_DIR/trials/$slug"
   runtime="fh-$(printf '%s' "$RUN_ID-$slug" | tr -c 'a-zA-Z0-9-' '-' | cut -c1-48)"
 
-  template=${CMD_TEMPLATE:-$(default_cmd "$suite")}
+  case "$suite" in
+    terminal-bench) template=$EFFECTIVE_TERMINAL_CMD ;;
+    datacurve) template=$EFFECTIVE_DATACURVE_CMD ;;
+    *) template="" ;;
+  esac
   if [ -z "$template" ]; then
     echo "no runner template for suite '$suite'; pass --cmd" >&2
     exit 1
@@ -152,6 +246,88 @@ while IFS= read -r entry || [ -n "$entry" ]; do
     continue
   fi
 
+  set +e
+  runta cp "$runtime:/work/manifest.json" "$trial_dir/manifest.json" \
+    >"$trial_dir/manifest-check.log" 2>&1
+  manifest_exit=$?
+  identity_exit=0
+  if [ "$manifest_exit" -eq 0 ] && [ "$HARNESS" = mcode ]; then
+    runta exec "$runtime" -- sh -lc 'set -eu
+      tasks_sha256=$(find /work/frontierharness-tasks -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d" " -f1)
+      terminal_bench_tasks_sha256=$(find /work/terminal-bench/tasks -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d" " -f1)
+      deep_swe_tasks_sha256=$(find /work/deep-swe/tasks -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -d" " -f1)
+      deep_swe_commit=$(git -C /work/deep-swe rev-parse HEAD)
+      mcode_bundle_sha256=$(sha256sum /work/mcode-runtime.tar.gz | cut -d" " -f1)
+      mcode_agent_sha256=$(sha256sum /work/frontierharness_mcode.py | cut -d" " -f1)
+      jq -n --arg tasks_sha256 "$tasks_sha256" \
+        --arg terminal_bench_tasks_sha256 "$terminal_bench_tasks_sha256" \
+        --arg deep_swe_tasks_sha256 "$deep_swe_tasks_sha256" \
+        --arg deep_swe_commit "$deep_swe_commit" \
+        --arg mcode_bundle_sha256 "$mcode_bundle_sha256" \
+        --arg mcode_agent_sha256 "$mcode_agent_sha256" \
+        "{tasks_sha256:\$tasks_sha256,
+          terminal_bench_tasks_sha256:\$terminal_bench_tasks_sha256,
+          deep_swe_tasks_sha256:\$deep_swe_tasks_sha256,
+          deep_swe_commit:\$deep_swe_commit,
+          mcode_bundle_sha256:\$mcode_bundle_sha256,
+          mcode_agent_sha256:\$mcode_agent_sha256}" \
+        > /work/evidence/checkpoint-identity.json' \
+      >>"$trial_dir/manifest-check.log" 2>&1
+    identity_exit=$?
+    if [ "$identity_exit" -eq 0 ]; then
+      runta cp "$runtime:/work/evidence/checkpoint-identity.json" \
+        "$trial_dir/checkpoint-identity.json" >>"$trial_dir/manifest-check.log" 2>&1
+      identity_exit=$?
+    fi
+  else
+    printf '{}\n' > "$trial_dir/checkpoint-identity.json"
+  fi
+  set -e
+  checkpoint_manifest=""
+  if [ "$manifest_exit" -eq 0 ]; then
+    checkpoint_manifest=$(cat "$trial_dir/manifest.json")
+  fi
+  manifest_valid=false
+  if [ "$manifest_exit" -eq 0 ] && [ "$identity_exit" -eq 0 ] && jq -e \
+      --slurpfile actual "$trial_dir/checkpoint-identity.json" \
+      --arg harness "$HARNESS" --arg harness_version "$HARNESS_VERSION" \
+      --arg model "$CHECKPOINT_MODEL" --arg provider "$PROVIDER" \
+      --arg terminal_dataset "$MCODE_TERMINAL_BENCH_DATASET" \
+      --arg deep_swe_commit "$MCODE_DEEP_SWE_COMMIT" \
+      '(.harness // "") == $harness and (.provider // "") == $provider and
+       (.model // "") == $model and
+       ($harness_version == "" or (.harness_version // "") == $harness_version) and
+       ($harness != "mcode" or
+         (.task_count == 30 and .terminal_bench_overlay_count == 21 and
+          .deep_swe_overlay_count == 9 and .terminal_bench_dataset == $terminal_dataset and
+          .deep_swe_commit == $deep_swe_commit and
+          ((.tasks_sha256 // "") | test("^[0-9a-f]{64}$")) and
+          ((.terminal_bench_tasks_sha256 // "") | test("^[0-9a-f]{64}$")) and
+          ((.deep_swe_tasks_sha256 // "") | test("^[0-9a-f]{64}$")) and
+          ((.mcode_bundle_sha256 // "") | test("^[0-9a-f]{64}$")) and
+          ((.mcode_agent_sha256 // "") | test("^[0-9a-f]{64}$")) and
+          .tasks_sha256 == $actual[0].tasks_sha256 and
+          .terminal_bench_tasks_sha256 == $actual[0].terminal_bench_tasks_sha256 and
+          .deep_swe_tasks_sha256 == $actual[0].deep_swe_tasks_sha256 and
+          .deep_swe_commit == $actual[0].deep_swe_commit and
+          .mcode_bundle_sha256 == $actual[0].mcode_bundle_sha256 and
+          .mcode_agent_sha256 == $actual[0].mcode_agent_sha256))' \
+      "$trial_dir/manifest.json" \
+      >/dev/null 2>&1; then
+    manifest_valid=true
+  fi
+  if [ "$manifest_valid" != true ]; then
+    echo "checkpoint manifest mismatch or incomplete task assets for $entry" >&2
+    jq -n --arg id "$entry" --arg t "$task" \
+      --arg observed_manifest "$checkpoint_manifest" \
+      '{id:$id, title:$t, status:"infra_invalid", success:false,
+        error:"checkpoint manifest mismatch or incomplete task assets",
+        observed_manifest:$observed_manifest}' \
+      > "$trial_dir/trial.json"
+    runta rm "$runtime" >/dev/null 2>&1 || true
+    continue
+  fi
+
   jobs_dir="/work/jobs/$slug"
   command=$(render "$template" "$task" "$suite" "$jobs_dir")
   started=$(date +%s)
@@ -167,16 +343,20 @@ while IFS= read -r entry || [ -n "$entry" ]; do
 
   runta cp "$runtime:$jobs_dir" "$trial_dir/jobs" >/dev/null 2>&1 \
     || echo "no job artifacts collected for $entry" >&2
-  runta cp "$runtime:/work/manifest.json" "$trial_dir/manifest.json" >/dev/null 2>&1 || true
   runta rm "$runtime" >/dev/null 2>&1 || echo "failed to delete runtime $runtime" >&2
 
-  reward=$(extract "$trial_dir/jobs" '[.. | objects | (.resolved?, .is_resolved?, .reward?, .passed?)] | map(select(. != null)) | .[0]')
+  reward=$(extract "$trial_dir/jobs" '[.. | objects |
+    (.verifier_result?.rewards?.reward?, .rewards?.reward?, .resolved?,
+     .is_resolved?, .passed?)] |
+    map(select(type == "number" or type == "boolean")) | .[0]')
+  exception=$(extract "$trial_dir/jobs" '[.. | objects | .exception_info?] |
+    map(select(. != null)) | .[0]')
   cost=$(extract "$trial_dir/jobs" '[.. | objects | (.total_cost_usd?, .total_cost?, .cost_usd?)] | map(select(type == "number")) | .[0]')
   turns=$(extract "$trial_dir/jobs" '[.. | objects | (.n_steps?, .num_turns?, .steps?)] | map(select(type == "number")) | .[0]')
   cache=$(extract "$trial_dir/jobs" '[.. | objects | (.cache_hit_rate?, .cache_read_ratio?)] | map(select(type == "number")) | .[0]')
 
-  case "$reward" in
-    true|1|1.0) success=true ;;
+  case "$reward:$exception" in
+    true:|1:|1.0:) success=true ;;
     *) success=false ;;
   esac
   if [ "$exit_code" -eq 124 ]; then
@@ -193,10 +373,12 @@ while IFS= read -r entry || [ -n "$entry" ]; do
     --arg id "$entry" --arg task "$task" --arg suite "$suite" --arg status "$status" \
     --arg runtime "$runtime" --arg checkpoint "$CHECKPOINT" \
     --argjson success "$success" --argjson duration "$duration" --argjson exit_code "$exit_code" \
+    --argjson exception_info "${exception:-null}" \
     --argjson cost "${cost:-null}" --argjson turns "${turns:-null}" --argjson cache "${cache:-null}" \
     '{id:$id, title:$task, suite:$suite, status:$status, success:$success,
       duration_seconds:$duration, cost_first_cold_usd:$cost, turns:$turns,
       cache_hit_rate_normalized:$cache, exit_code:$exit_code,
+      exception_info:$exception_info,
       runtime:$runtime, checkpoint:$checkpoint,
       included_in_efficiency:$success}' \
     > "$trial_dir/trial.json"

--- a/skills/frontierharness-eval/tests/test-minimax-code.sh
+++ b/skills/frontierharness-eval/tests/test-minimax-code.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+RUNNER="$ROOT/scripts/run-minimax-code.sh"
+PROVISIONER="$ROOT/scripts/provision-golden-checkpoint.sh"
+RUN_TRIALS="$ROOT/scripts/run-trials.sh"
+
+assert_contains() {
+  case "$1" in
+    *"$2"*) ;;
+    *) echo "expected command to contain: $2" >&2; exit 1 ;;
+  esac
+}
+
+bash -n "$RUNNER" "$PROVISIONER"
+python3 -c 'import ast, pathlib, sys; ast.parse(pathlib.Path(sys.argv[1]).read_text())' \
+  "$ROOT/agents/frontierharness_mcode.py"
+
+fireworks=$($RUNNER --provider fireworks --print-command)
+assert_contains "$fireworks" 'OPENAI_API_KEY="$FIREWORKS_API_KEY"'
+assert_contains "$fireworks" 'OPENAI_BASE_URL="https://api.fireworks.ai/inference/v1"'
+assert_contains "$fireworks" '-m openai/accounts/fireworks/models/kimi-k3'
+assert_contains "$fireworks" '-p /work/terminal-bench/tasks --include-task-name {task}'
+case "$fireworks" in
+  *@latest*) echo "Terminal-Bench must use an immutable content digest" >&2; exit 1 ;;
+esac
+assert_contains "$fireworks" '-p /work/deep-swe/tasks'
+assert_contains "$fireworks" '--ak version=0.2.7'
+assert_contains "$fireworks" '-a frontierharness_mcode:OfflineMCode'
+assert_contains "$fireworks" 'PYTHONPATH=/work'
+assert_contains "$fireworks" '--ak bundle_path=/work/mcode-runtime.tar.gz'
+assert_contains "$fireworks" '--allow-agent-host api.fireworks.ai'
+assert_contains "$(cat "$PROVISIONER")" 'terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a'
+
+moonshot=$($RUNNER --provider moonshot --print-command)
+assert_contains "$moonshot" 'OPENAI_API_KEY="$MOONSHOT_API_KEY"'
+assert_contains "$moonshot" '-m openai/kimi-k3'
+
+openrouter=$($RUNNER --provider openrouter --print-command)
+assert_contains "$openrouter" '-m openrouter/moonshotai/kimi-k3'
+case "$openrouter" in
+  *OPENAI_API_KEY*) echo "OpenRouter command unexpectedly remapped its credential" >&2; exit 1 ;;
+esac
+
+together=$($RUNNER --provider together --print-command)
+assert_contains "$together" '-m together/moonshotai/Kimi-K3'
+assert_contains "$together" '--ak version=0.2.7'
+
+if $RUNNER --provider custom --print-command >/dev/null 2>&1; then
+  echo "custom provider should require the generic --cmd path" >&2
+  exit 1
+fi
+
+if $RUNNER --mcode-version 0.2.6 --print-command >/dev/null 2>&1; then
+  echo "the pinned profile should reject MCode version overrides" >&2
+  exit 1
+fi
+
+if $RUNNER --model 'openai/kimi-k3;false' --print-command >/dev/null 2>&1; then
+  echo "unsafe model route should be rejected" >&2
+  exit 1
+fi
+
+if $RUNNER --timeout '30;false' --print-command >/dev/null 2>&1; then
+  echo "unsafe timeout should be rejected" >&2
+  exit 1
+fi
+
+if RUNTA_TOKEN=x FIREWORKS_API_KEY=x "$PROVISIONER" \
+  --runtime test --checkpoint test --harness test --repo https://example.test/repo \
+  >/dev/null 2>&1; then
+  echo "--repo without --commit should be rejected" >&2
+  exit 1
+fi
+
+# Exercise the real wrapper-to-run-trials boundary with a fake Runta CLI. The runner
+# may fail the mock trials, but each suite must receive its own Harbor source.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/runta" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$RUNTA_LOG"
+case "$1" in
+  exec) exit 0 ;;
+  cp)
+    case "${2:-}" in
+      fh-*:/work/manifest.json)
+        mkdir -p "$(dirname "$3")"
+        case "$2" in
+          fh-test-*|fh-identity-mismatch-*)
+            printf '%s\n' '{"harness":"mcode","harness_version":"0.2.7","model":"fireworks_ai/accounts/fireworks/models/kimi-k3","provider":"fireworks","task_count":30,"terminal_bench_overlay_count":21,"deep_swe_overlay_count":9,"terminal_bench_dataset":"terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a","tasks_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","terminal_bench_tasks_sha256":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","deep_swe_tasks_sha256":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","deep_swe_commit":"435ee89ec2f2e2289f33b0da4f992f0b7b7266b9","mcode_bundle_sha256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","mcode_agent_sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}' > "$3"
+            ;;
+          fh-version-mismatch-*)
+            printf '%s\n' '{"harness":"nop","harness_version":"0.2.7","model":"fireworks_ai/accounts/fireworks/models/kimi-k3","provider":"fireworks"}' > "$3"
+            ;;
+          *) printf '%s\n' '{"harness":"nop","harness_version":"","model":"fireworks_ai/accounts/fireworks/models/kimi-k3","provider":"fireworks"}' > "$3" ;;
+        esac
+        exit 0
+        ;;
+      *:/work/evidence/checkpoint-identity.json)
+        mkdir -p "$(dirname "$3")"
+        case "$2" in
+          fh-identity-mismatch-*) tasks_sha256=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff ;;
+          *) tasks_sha256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ;;
+        esac
+        printf '%s\n' "{\"tasks_sha256\":\"$tasks_sha256\",\"terminal_bench_tasks_sha256\":\"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\",\"deep_swe_tasks_sha256\":\"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\",\"deep_swe_commit\":\"435ee89ec2f2e2289f33b0da4f992f0b7b7266b9\",\"mcode_bundle_sha256\":\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\",\"mcode_agent_sha256\":\"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"}" > "$3"
+        exit 0
+        ;;
+      *:/work/jobs/*)
+        mkdir -p "$3"
+        case "$2" in
+          *anko-typed-variable-bindings*)
+            printf '%s\n' '{"trials":[{"exception_info":{"exception_type":"AgentError"},"verifier_result":{"rewards":{"reward":1.0}}}]}' > "$3/result.json"
+            ;;
+          *)
+            printf '%s\n' '{"reward_stats":{"reward":{"1.0":["trial"]}},"trials":[{"exception_info":null,"verifier_result":{"rewards":{"reward":1.0}}}]}' > "$3/result.json"
+            ;;
+        esac
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+MOCK
+chmod +x "$TMP/bin/runta"
+printf '%s\n' terminal-bench/regex-log datacurve/anko-typed-variable-bindings > "$TMP/tasks.txt"
+
+: > "$TMP/runta.log"
+RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test FIREWORKS_API_KEY=test PATH="$TMP/bin:$PATH" \
+  "$PROVISIONER" --runtime test --checkpoint test --harness mcode \
+  --harness-version 0.2.7 --harbor-version 0.22.0 --harbor-only \
+  --copy-tasks "$ROOT/../../tasks" >/dev/null 2>&1
+provision_log=$(cat "$TMP/runta.log")
+assert_contains "$provision_log" 'frontierharness_mcode.py'
+assert_contains "$provision_log" 'node-v22.23.2-linux-x64.tar.gz'
+assert_contains "$provision_log" "@minimax-ai/code@0.2.7"
+assert_contains "$provision_log" 'terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a'
+
+printf '%s\n' 'terminal-bench/regex-log;false' > "$TMP/unsafe-tasks.txt"
+if RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test PATH="$TMP/bin:$PATH" \
+  "$RUN_TRIALS" --checkpoint test --harness nop --run-id unsafe-task \
+  --tasks "$TMP/unsafe-tasks.txt" --out "$TMP/unsafe-runs" >/dev/null 2>&1; then
+  echo "unsafe task ID should be rejected" >&2
+  exit 1
+fi
+
+RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test PATH="$TMP/bin:$PATH" \
+  "$RUNNER" --checkpoint test --run-id test --tasks "$TMP/tasks.txt" \
+  --out "$TMP/runs" >/dev/null 2>&1
+
+assert_contains "$(cat "$TMP/runta.log")" '-p /work/terminal-bench/tasks --include-task-name regex-log'
+assert_contains "$(cat "$TMP/runs/test/run.json")" '"harness_version": "0.2.7"'
+jq -e '(.terminal_command_sha256 | test("^[0-9a-f]{64}$")) and
+       (.datacurve_command_sha256 | test("^[0-9a-f]{64}$")) and
+       (has("terminal_command_template") | not) and
+       (has("datacurve_command_template") | not)' "$TMP/runs/test/run.json" >/dev/null
+assert_contains "$(cat "$TMP/runta.log")" '-p /work/deep-swe/tasks --include-task-name anko-typed-variable-bindings'
+jq -e '.status == "success" and .success == true' \
+  "$TMP/runs/test/trials/terminal-bench-regex-log/trial.json" >/dev/null
+jq -e '.status == "failure" and .success == false and .exception_info.exception_type == "AgentError"' \
+  "$TMP/runs/test/trials/datacurve-anko-typed-variable-bindings/trial.json" >/dev/null
+
+: > "$TMP/runta.log"
+printf '%s\n' terminal-bench/regex-log > "$TMP/terminal-tasks.txt"
+RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test PATH="$TMP/bin:$PATH" \
+  "$RUNNER" --checkpoint test --run-id identity-mismatch \
+  --tasks "$TMP/terminal-tasks.txt" --out "$TMP/identity-runs" >/dev/null 2>&1
+jq -e '.status == "infra_invalid" and .error == "checkpoint manifest mismatch or incomplete task assets"' \
+  "$TMP/identity-runs/identity-mismatch/trials/terminal-bench-regex-log/trial.json" >/dev/null
+
+RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test PATH="$TMP/bin:$PATH" \
+  "$RUN_TRIALS" --checkpoint test --harness nop --harness-version 0.2.6 \
+  --run-id version-mismatch --tasks "$TMP/terminal-tasks.txt" \
+  --out "$TMP/mismatch-runs" >/dev/null 2>&1
+jq -e '.status == "infra_invalid" and .error == "checkpoint manifest mismatch or incomplete task assets"' \
+  "$TMP/mismatch-runs/version-mismatch/trials/terminal-bench-regex-log/trial.json" >/dev/null
+
+RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test PATH="$TMP/bin:$PATH" \
+  "$RUN_TRIALS" --checkpoint test --harness nop --provider moonshot \
+  --run-id provider-mismatch --tasks "$TMP/terminal-tasks.txt" \
+  --out "$TMP/provider-runs" >/dev/null 2>&1
+jq -e '.status == "infra_invalid" and .error == "checkpoint manifest mismatch or incomplete task assets"' \
+  "$TMP/provider-runs/provider-mismatch/trials/terminal-bench-regex-log/trial.json" >/dev/null
+
+: > "$TMP/runta.log"
+RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test PATH="$TMP/bin:$PATH" \
+  "$RUN_TRIALS" --checkpoint test --harness nop --run-id default-template \
+  --tasks "$TMP/terminal-tasks.txt" --out "$TMP/default-runs" >/dev/null 2>&1
+assert_contains "$(cat "$TMP/runta.log")" 'terminal-bench/terminal-bench-2-1@sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a --include-task-name terminal-bench/regex-log'
+
+if RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test PATH="$TMP/bin:$PATH" \
+  "$RUN_TRIALS" --checkpoint different --harness nop --run-id default-template \
+  --tasks "$TMP/terminal-tasks.txt" --out "$TMP/default-runs" >/dev/null 2>&1; then
+  echo "an existing run ID should reject mixed immutable configuration" >&2
+  exit 1
+fi
+
+if RUNTA_LOG="$TMP/runta.log" RUNTA_TOKEN=test PATH="$TMP/bin:$PATH" \
+  "$RUN_TRIALS" --checkpoint test --harness nop --run-id default-template \
+  --tasks "$TMP/terminal-tasks.txt" --out "$TMP/default-runs" --timeout 60 \
+  >/dev/null 2>&1; then
+  echo "an existing run ID should reject a different timeout" >&2
+  exit 1
+fi
+
+echo "MiniMax Code profile tests passed"


### PR DESCRIPTION
## Summary

- add a reproducible MiniMax Code profile that runs all 30 published task IDs through Harbor's `mcode` adapter
- replace MCode's networked per-task install with a checkpointed, SHA-256-verified Node/MCode bundle while preserving Harbor's normal configuration, execution, and trajectory paths
- pin Harbor, MiniMax Code, Node, Terminal-Bench, and DeepSWE inputs; overlay the repository's public task definitions onto the complete upstream task assets
- add Fireworks, Moonshot, OpenRouter, and Together Kimi K3 mappings, checkpoint/run identity checks, evidence collection, reporting metadata, and focused regression tests

## Reproducibility pins

- Harbor `0.22.0`
- `@minimax-ai/code` `0.2.7`
- Node.js `22.23.2` (official Linux x64 archive SHA-256 verified)
- Terminal-Bench 2.1 dataset `sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a`
- DeepSWE commit `435ee89ec2f2e2289f33b0da4f992f0b7b7266b9`

Every restored MCode checkpoint recomputes and compares the public-task tree, runnable Terminal-Bench and DeepSWE trees, MCode bundle, adapter source, and DeepSWE HEAD before a trial can run. An existing run ID also rejects changes to the checkpoint, harness/version, provider/model routes, timeout, or command identities.

## Validation

- `skills/frontierharness-eval/tests/test-minimax-code.sh`
- `bash -n skills/frontierharness-eval/scripts/*.sh skills/frontierharness-eval/tests/*.sh`
- `node --check skills/frontierharness-eval/scripts/*.mjs`
- `uvx ruff check skills/frontierharness-eval/agents/frontierharness_mcode.py`
- skill metadata validation with Codex's `quick_validate.py`
- Harbor `0.22.0` resolution and full export of the pinned Terminal-Bench digest; verified all 21 selected Terminal-Bench and 9 DeepSWE overlays load from the resulting local task trees
- offline adapter install contract test and Harbor custom-agent `--print-config` validation

I did not run a real Runta/Kimi K3 task or the full 30-task sweep from this environment: it has no Runta/provider credentials and its Docker daemon is unavailable. This PR adds the reproducible integration workflow, not benchmark result claims.

## Stack

This PR is intentionally based on and targets #1 (`feat/third-part-harness`), which introduces the agent-neutral evaluation workflow that this MiniMax Code profile extends.
