### PR TITLE
Add Cursor CLI evaluation profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Cost is compared on `effective_cost_per_pass`, which is total cost across all ta
 
 Metric definitions and the trial record contract are in [`SKILL.md`](skills/frontierharness-eval/SKILL.md). Runner templates, the alternative Harbor-with-Runta-provider topology, and troubleshooting are in [`reference.md`](skills/frontierharness-eval/reference.md).
 
+Cursor's headless CLI has a ready-made profile: Harbor and Pier both ship a `cursor-cli` adapter, so [`cursor-cli.md`](skills/frontierharness-eval/cursor-cli.md) only fixes the provider, hands the adapter Kimi K3 prices, and states where the row deviates from the baselines (model calls go through Cursor's backend, so it lands with a provider caveat).
+
+```bash
+$FH/run-cursor-cli.sh --print-command
+```
+
 ## Methodology
 
 ### Tested harness configurations

--- a/skills/frontierharness-eval/SKILL.md
+++ b/skills/frontierharness-eval/SKILL.md
@@ -43,6 +43,7 @@ is not Kimi K3, and refuse an unknown provider name.
 | `moonshot` | `moonshot/kimi-k3` | `MOONSHOT_API_KEY` |
 | `openrouter` | `openrouter/moonshotai/kimi-k3` | `OPENROUTER_API_KEY` |
 | `together` | `together_ai/moonshotai/Kimi-K3` | `TOGETHER_API_KEY` |
+| `cursor` (only with `--harness cursor-cli`, see `cursor-cli.md`) | `kimi-k3` via Cursor's backend | `CURSOR_API_KEY` |
 | `custom` | supply `--model` | supply `--secret-name` |
 
 Ask which provider the user has a key for, and use `--provider fireworks` if they have
@@ -252,5 +253,6 @@ values.
 ## Additional resources
 
 - Command reference, runner templates, and troubleshooting: [reference.md](reference.md)
+- Cursor CLI through Harbor and Pier: [cursor-cli.md](cursor-cli.md)
 - Published results and task definitions: `results/eval-data.json`, `tasks/<task>/task.toml`
 - Source evaluation: <https://frontierharness.org/>

--- a/skills/frontierharness-eval/cursor-cli.md
+++ b/skills/frontierharness-eval/cursor-cli.md
@@ -1,0 +1,156 @@
+# Cursor CLI through Harbor and Pier
+
+Use this profile when the harness under evaluation is
+[Cursor](https://cursor.com/) driven headlessly through its CLI (`cursor-agent`). Both
+runners already ship an adapter for it, named `cursor-cli` in each, so there is no agent
+to register: the profile fixes the provider, hands the adapter Kimi K3 prices, and
+states where a Cursor row deviates from the twelve baselines so it lands with the right
+caveats.
+
+Kimi K3 is a supported Cursor model (`--model kimi-k3`), so the benchmark's fixed-model
+rule holds without a workaround.
+
+## Where this row deviates
+
+| | Baselines | Cursor CLI |
+| --- | --- | --- |
+| Model call | Harness calls the provider directly; `--provider` picks the route and key | CLI calls Cursor's backend, which calls Cursor's inference partner for Kimi K3 (Moonshot, per Cursor's pricing page). Cursor's custom-key setting is documented for chat only, not the CLI. |
+| Credential | Provider key, injected by the egress proxy on the provider host | `CURSOR_API_KEY`, injected on `api2.cursor.sh` |
+| Version pin | Source checkout at a commit | The installed CLI version, read back from every trial. Part of Cursor's context assembly runs on its backend and has no version. |
+| Cost source | Trajectory token counts at provider list prices | Token counts from the CLI's `stream-json` result event, priced at Cursor's Kimi K3 list prices |
+
+Same weights, so **pass rate is comparable**. Cache hit rate may differ with the
+partner's prefix-cache behaviour, which `reference.md` § Cost comparability already
+treats as a caveat category. `build-report.mjs` flags the provider as non-baseline
+automatically because `--provider cursor` is not Fireworks.
+
+## Prerequisites
+
+A Cursor API key from the Cursor dashboard, on a plan that allows API-key use of the CLI.
+Note which plan: Cursor lists a **Cursor Token Rate** of $0.25 per million tokens on top
+of model pricing for Teams and Enterprise plans, and none for individual plans. The rate
+you were billed at goes into `--cursor-token-rate` below and into the report.
+
+```bash
+FH=skills/frontierharness-eval/scripts
+export RUNTA_TOKEN=rt_...
+export CURSOR_API_KEY=...
+```
+
+## Provision the golden checkpoint
+
+There is no source to clone: the adapters install `cursor-agent` inside each task
+container from Cursor's installer at trial time. Pin the version you expect instead of a
+commit, then confirm it after the run (below).
+
+```bash
+$FH/provision-golden-checkpoint.sh \
+  --runtime fh-build-cursor \
+  --checkpoint fh-golden-cursor-cli-v1 \
+  --harness cursor-cli \
+  --harness-version "$(cursor-agent --version 2>/dev/null || echo unknown)" \
+  --provider cursor \
+  --cpus 4 --memory 8192 --disk-size-gib 100 \
+  --prepull-tasks tasks
+```
+
+`--provider cursor` stores `CURSOR_API_KEY` as a Runta secret stub and records
+`api2.cursor.sh` as the host the key is injected on. If you restrict egress
+(`reference.md` § Model and providers), allow `cursor.com` for the installer and
+`api.cursor.sh`, `api2.cursor.sh`, `api3.cursor.sh` for the CLI; these are the domains
+Pier's own `cursor-cli` adapter allowlists.
+
+## Smoke-test the integration
+
+Render the Harbor command first; it needs no credentials or runtime:
+
+```bash
+$FH/run-cursor-cli.sh --print-command
+```
+
+Then run one Terminal-Bench task and one DeepSWE task from fresh restores before
+spending a full sweep:
+
+```bash
+printf '%s\n' terminal-bench/regex-log datacurve/anko-typed-variable-bindings > tasks-cursor-smoke.txt
+
+$FH/run-cursor-cli.sh \
+  --checkpoint fh-golden-cursor-cli-v1 \
+  --run-id cursor-cli-smoke \
+  --tasks tasks-cursor-smoke.txt
+```
+
+Check the collected `cursor-cli.txt` stream in each trial's jobs before going on. Each
+line settles one of this profile's open points:
+
+1. The `system` / `init` event has `apiKeySource: "env"` and names the Kimi K3 model.
+   Anything else means the CLI did not pick the key up from the runtime.
+2. The first assistant turn succeeded. The runtime holds only the stub value, and the
+   egress proxy swaps it into the `Authorization` header on `api2.cursor.sh`. Whether the
+   CLI authenticates with that header shape against that host is not documented, so a
+   working first turn is the proof. If auth fails, the fallback is a `--cmd` that exports
+   the real key into the trial runtime, which leaves the stub model and has to be stated
+   in the report.
+3. The `result` event carries a `usage` object with `inputTokens`, `outputTokens`,
+   `cacheReadTokens`, and `cacheWriteTokens`. Both adapters parse it into token totals
+   and cache-hit rate; without it the cache column is empty. Cursor's public
+   `output-format` reference does not list `usage`, so which CLI versions emit it is
+   something the smoke run establishes.
+4. `agent_info.version` in the Harbor job is the version you passed as
+   `--harness-version`.
+
+A model response without a verifier result is not a successful smoke test.
+
+## Run the published task set
+
+```bash
+$FH/run-cursor-cli.sh \
+  --checkpoint fh-golden-cursor-cli-v1 \
+  --run-id "$(date +%Y-%m-%d)-cursor-cli" \
+  --cursor-token-rate 0      # 0.25 on Teams and Enterprise
+```
+
+With no `--tasks` this is the repo's `tasks/` directory, the published 30. The wrapper
+runs the 21 Terminal-Bench tasks through Harbor and the 9 DeepSWE tasks through Pier
+under one run id, then reports the set of `cursor-agent` versions seen. More than one
+version means the run is not one configuration; rerun the odd trials.
+
+Then score and chart it the normal way:
+
+```bash
+node $FH/normalize-results.mjs --run runs/<run-id> --label "Cursor CLI"
+node $FH/generate-chart.mjs    --run runs/<run-id>
+node $FH/build-report.mjs      --run runs/<run-id>
+```
+
+## Cost
+
+Harbor's `cursor-cli` adapter has built-in rates for Cursor's own models but none for
+`kimi-k3`, so the wrapper passes Cursor's listed Kimi K3 prices through the adapter's
+`pricing` kwarg: $3 input, $0.30 cache read, $15 output per million, cache writes at the
+input rate, each plus `--cursor-token-rate`. These match the Fireworks and Moonshot list
+prices behind the baselines, so at a token rate of 0 the cost column is comparable to
+the same degree as any non-Fireworks provider.
+
+Pier's `cursor-cli` adapter has no pricing override and falls back to a LiteLLM lookup
+of the bare model name, which has no entry for `kimi-k3`. The 9 DeepSWE trials therefore
+carry token counts but an empty cost. Do not estimate silently: either leave
+`effective_cost_per_pass` as the Terminal-Bench-only figure and say so in the report, or
+join per-task cost from Cursor's usage data and state the method.
+
+## Versioning
+
+`harness-versions.json` rows for the baselines carry a version from `agent_info.version`.
+A Cursor row carries the same, plus the run date, because the backend half of the
+harness cannot be pinned. This is weaker than the other rows and is worth recording as
+such rather than omitting.
+
+## What this profile does not do
+
+- It does not drive the Cursor desktop Agent, which honours custom keys and a base-URL
+  override and could in principle hit the same Fireworks route as the baselines. If Cursor
+  exposes that override in the CLI, `--provider fireworks` with `--harness cursor-cli`
+  becomes the straight-peer configuration and this profile's provider caveat disappears.
+- It does not bundle a pinned CLI into the checkpoint. That would make the version pin as
+  strong as the baselines' commit pin; add it when the per-trial installer proves to
+  drift within a run.

--- a/skills/frontierharness-eval/reference.md
+++ b/skills/frontierharness-eval/reference.md
@@ -38,7 +38,13 @@ comparable pass rate. Select one with `--provider`; the presets live in
 | `moonshot` | `moonshot/kimi-k3` | `MOONSHOT_API_KEY` | `api.moonshot.ai` |
 | `openrouter` | `openrouter/moonshotai/kimi-k3` | `OPENROUTER_API_KEY` | `openrouter.ai` |
 | `together` | `together_ai/moonshotai/Kimi-K3` | `TOGETHER_API_KEY` | `api.together.xyz` |
+| `cursor` (only with `--harness cursor-cli`) | `kimi-k3`, Cursor's own model slug | `CURSOR_API_KEY` | `api2.cursor.sh` |
 | `custom` | `--model` (required) | `--secret-name` (required) | set egress yourself |
+
+`cursor` is the one preset that is not a provider in the same sense: Cursor's headless CLI
+sends model calls through Cursor's backend to Cursor's inference partner for Kimi K3, so
+it pairs only with the `cursor-cli` harness and lands with a provider caveat. Details,
+egress hosts, and pricing: [cursor-cli.md](cursor-cli.md).
 
 The provider prefix is the LiteLLM provider route, which is what Harbor, Pier, and
 `mini-swe-agent` expect. A harness that calls the provider directly through an

--- a/skills/frontierharness-eval/scripts/build-report.mjs
+++ b/skills/frontierharness-eval/scripts/build-report.mjs
@@ -130,7 +130,8 @@ ${comparison}
 | Model | \`${candidate.model ?? "unspecified"}\` |
 | Provider | ${candidate.provider ? `\`${candidate.provider}\`` : "unspecified"} |
 | Harness repo | ${manifest?.harness_repo ? `\`${manifest.harness_repo}\`` : "see manifest"} |
-| Harness commit | \`${manifest?.harness_commit ?? "unknown"}\` |
+| Harness commit | \`${manifest?.harness_commit || "unknown"}\` |
+| Harness version | \`${manifest?.harness_version || "see trajectories"}\` |
 | Runtime | ${manifest ? `${manifest.cpus} vCPU, ${manifest.memory_mib} MiB` : "see manifest"} |
 | Harbor | \`${manifest?.harbor_version ?? "unknown"}\` |
 | Pier | \`${manifest?.pier_version ?? "unknown"}\` |

--- a/skills/frontierharness-eval/scripts/providers.sh
+++ b/skills/frontierharness-eval/scripts/providers.sh
@@ -5,7 +5,7 @@
 # the same model produces a comparable pass rate. Model strings use the LiteLLM provider
 # route, which is what Harbor, Pier, and mini-swe-agent expect.
 
-PROVIDER_LIST="fireworks moonshot openrouter together custom"
+PROVIDER_LIST="fireworks moonshot openrouter together cursor custom"
 
 # Sets PROVIDER_MODEL, PROVIDER_SECRET, and PROVIDER_HOST. Returns 1 on unknown input.
 resolve_provider() {
@@ -26,6 +26,15 @@ resolve_provider() {
       PROVIDER_MODEL="together_ai/moonshotai/Kimi-K3"
       PROVIDER_SECRET="TOGETHER_API_KEY"
       PROVIDER_HOST="api.together.xyz" ;;
+    cursor)
+      # Cursor's headless CLI is not a LiteLLM route: it takes Cursor's own model slug and
+      # sends every model call through Cursor's backend to Cursor's inference partner for
+      # Kimi K3 (Moonshot on its pricing page), so the row carries a provider caveat. The
+      # credential is Cursor's API key, injected on the backend host the CLI talks to.
+      # Only meaningful with --harness cursor-cli; see cursor-cli.md.
+      PROVIDER_MODEL="kimi-k3"
+      PROVIDER_SECRET="CURSOR_API_KEY"
+      PROVIDER_HOST="api2.cursor.sh" ;;
     custom)
       # Anything else: --model and --secret-name must be supplied explicitly.
       PROVIDER_MODEL=""

--- a/skills/frontierharness-eval/scripts/provision-golden-checkpoint.sh
+++ b/skills/frontierharness-eval/scripts/provision-golden-checkpoint.sh
@@ -15,6 +15,7 @@ CHECKPOINT=""
 HARNESS=""
 REPO=""
 COMMIT=""
+HARNESS_VERSION=""
 MODEL=""
 SECRET_NAME=""
 INSTALL_SCRIPT=""
@@ -28,7 +29,8 @@ KEEP_RUNTIME=0
 usage() {
   cat <<EOF
 Usage: provision-golden-checkpoint.sh --runtime NAME --checkpoint NAME --harness NAME
-                                      --repo URL --commit SHA [options]
+                                      (--repo URL --commit SHA | --harness-version VER)
+                                      [options]
 
 Required:
   --runtime NAME        Name for the build runtime (deleted unless --keep-runtime)
@@ -36,6 +38,9 @@ Required:
   --harness NAME        Harness identifier used in reports, e.g. my-harness
   --repo URL            GitHub repo of the harness under evaluation
   --commit SHA          Commit to pin the harness to
+  --harness-version VER Instead of --repo/--commit, for a harness the runner installs
+                        itself (a Harbor or Pier built-in agent such as cursor-cli):
+                        the version the run is expected to report
 
 Options:
   --provider NAME       Kimi K3 provider (default fireworks, as used by the published
@@ -64,6 +69,7 @@ while [ $# -gt 0 ]; do
     --harness) HARNESS=$2; shift 2 ;;
     --repo) REPO=$2; shift 2 ;;
     --commit) COMMIT=$2; shift 2 ;;
+    --harness-version) HARNESS_VERSION=$2; shift 2 ;;
     --provider) PROVIDER=$2; shift 2 ;;
     --model) MODEL=$2; shift 2 ;;
     --secret-name) SECRET_NAME=$2; shift 2 ;;
@@ -79,13 +85,27 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-for required in RUNTIME CHECKPOINT HARNESS REPO COMMIT; do
+for required in RUNTIME CHECKPOINT HARNESS; do
   if [ -z "${!required}" ]; then
     echo "missing --$(echo "$required" | tr 'A-Z_' 'a-z-')" >&2
     usage >&2
     exit 2
   fi
 done
+
+# A harness is pinned one of two ways: a source checkout at a commit, or, when the runner
+# installs it itself, the version it must report. One of the two, never neither.
+if [ -n "$REPO" ] || [ -n "$COMMIT" ]; then
+  if [ -z "$REPO" ] || [ -z "$COMMIT" ]; then
+    echo "--repo and --commit go together" >&2
+    usage >&2
+    exit 2
+  fi
+elif [ -z "$HARNESS_VERSION" ]; then
+  echo "pin the harness with --repo URL --commit SHA, or --harness-version VER for a runner-built-in harness" >&2
+  usage >&2
+  exit 2
+fi
 
 case "$DISK_GIB" in
   ''|*[!0-9]*) echo "--disk-size-gib must be a whole number of GiB" >&2; exit 2 ;;
@@ -150,14 +170,19 @@ rexec 'set -eu
   command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
   mkdir -p /work/jobs /work/evidence'
 
-step "4/9 cloning $REPO at $COMMIT"
-rexec "set -eu
-  export PATH=\"\$HOME/.local/bin:\$PATH\"
-  rm -rf /work/harness
-  git clone --quiet '$REPO' /work/harness
-  cd /work/harness
-  git checkout --quiet '$COMMIT'
-  git rev-parse HEAD"
+if [ -n "$REPO" ]; then
+  step "4/9 cloning $REPO at $COMMIT"
+  rexec "set -eu
+    export PATH=\"\$HOME/.local/bin:\$PATH\"
+    rm -rf /work/harness
+    git clone --quiet '$REPO' /work/harness
+    cd /work/harness
+    git checkout --quiet '$COMMIT'
+    git rev-parse HEAD"
+else
+  step "4/9 no harness source to clone: the runner installs $HARNESS $HARNESS_VERSION per trial"
+  rexec "mkdir -p /work/harness"
+fi
 
 step "5/9 installing Harbor, Pier, and the deep-swe corpus"
 rexec "set -eu
@@ -234,8 +259,9 @@ rexec "set -eu
 {
   \"harness\": \"$HARNESS\",
   \"harness_repo\": \"$REPO\",
-  \"harness_commit\": \"\$(git rev-parse HEAD)\",
+  \"harness_commit\": \"\$(git rev-parse HEAD 2>/dev/null || true)\",
   \"harness_describe\": \"\$(git describe --tags --always 2>/dev/null || echo unknown)\",
+  \"harness_version\": \"$HARNESS_VERSION\",
   \"model\": \"$MODEL\",
   \"provider\": \"$PROVIDER\",
   \"provider_host\": \"$PROVIDER_HOST\",

--- a/skills/frontierharness-eval/scripts/run-cursor-cli.sh
+++ b/skills/frontierharness-eval/scripts/run-cursor-cli.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Run the benchmark through Cursor's headless CLI using the `cursor-cli` agent that
+# Harbor and Pier both ship. A thin wrapper over run-trials.sh: it fixes the provider and
+# harness, hands Kimi K3 token prices to Harbor's adapter, splits the two suites so each
+# gets its own runner template, and checks the CLI version was the same in every trial.
+# Background and caveats: ../cursor-cli.md
+set -euo pipefail
+
+FH=$(cd "$(dirname "$0")" && pwd)
+
+CHECKPOINT=""
+RUN_ID=""
+TASKS="tasks"
+OUT="runs"
+TIMEOUT=5400
+TOKEN_RATE=0
+PRINT_ONLY=0
+
+usage() {
+  cat <<EOF
+Usage: run-cursor-cli.sh --checkpoint NAME --run-id ID [--tasks PATH] [--out DIR]
+                         [--timeout SEC] [--cursor-token-rate USD_PER_M] [--print-command]
+
+  --tasks PATH             Task directory or list file, exactly as run-trials.sh takes it
+  --out DIR                Root output directory (default runs)
+  --timeout SEC            Per-task timeout (default 5400)
+  --cursor-token-rate N    Cursor Token Rate in USD per million tokens, added to every
+                           rate below. Cursor lists 0.25 for Teams and Enterprise plans
+                           and none for individual plans. Default 0.
+  --print-command          Render the Harbor template and exit; needs no credentials
+
+Terminal-Bench tasks run through Harbor with Kimi K3 list prices passed to the cursor-cli
+adapter, since Harbor has no built-in rate for kimi-k3. DeepSWE tasks run through Pier's
+cursor-cli adapter, which takes no pricing override, so their cost field stays empty and
+must be joined from Cursor's usage data if it is reported at all. See cursor-cli.md.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --checkpoint) CHECKPOINT=$2; shift 2 ;;
+    --run-id) RUN_ID=$2; shift 2 ;;
+    --tasks) TASKS=$2; shift 2 ;;
+    --out) OUT=$2; shift 2 ;;
+    --timeout) TIMEOUT=$2; shift 2 ;;
+    --cursor-token-rate) TOKEN_RATE=$2; shift 2 ;;
+    --print-command) PRINT_ONLY=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+case "$TOKEN_RATE" in
+  ''|*[!0-9.]*|*.*.*) echo "--cursor-token-rate must be a non-negative decimal" >&2; exit 2 ;;
+esac
+
+# Kimi K3 on Cursor's pricing page: $3 input, $0.30 cache read, $15 output per million,
+# no cache-write line. cacheWriteTokens are still input tokens the provider processed, so
+# they are priced at the input rate, which is also what Harbor does when the key is
+# omitted; it is written out so the rate in the evidence is explicit.
+rate() { awk -v base="$1" -v extra="$TOKEN_RATE" 'BEGIN { printf "%g", base + extra }'; }
+PRICING=$(printf '{"input":%s,"output":%s,"cache_read":%s,"cache_write":%s}' \
+  "$(rate 3)" "$(rate 15)" "$(rate 0.3)" "$(rate 3)")
+
+# The default Terminal-Bench template from run-trials.sh, plus the pricing kwarg.
+# run-trials.sh has no way to append to its default, so the template is restated here;
+# keep it in step with default_cmd() there.
+HARBOR_CMD="harbor run -d terminal-bench@2.0 -i {task} -a {harness} -m {model} --jobs-dir {jobs} --extra-docker-compose /work/runta-ca-overlay.yaml -r 2 -y --ak pricing='$PRICING'"
+
+if [ "$PRINT_ONLY" -eq 1 ]; then
+  echo "$HARBOR_CMD"
+  exit 0
+fi
+
+for required in CHECKPOINT RUN_ID; do
+  if [ -z "${!required}" ]; then
+    echo "missing --$(echo "$required" | tr 'A-Z_' 'a-z-')" >&2
+    usage >&2
+    exit 2
+  fi
+done
+
+# Split the task set by suite so each half gets its runner template. Reads the same two
+# shapes run-trials.sh accepts: a directory of task.toml files, or a list file.
+ALL=$(mktemp); TB=$(mktemp); DS=$(mktemp)
+trap 'rm -f "$ALL" "$TB" "$DS"' EXIT
+if [ -d "$TASKS" ]; then
+  for toml in "$TASKS"/*/task.toml; do
+    [ -r "$toml" ] || continue
+    awk -F'"' '/^\[/ { in_task = ($0 == "[task]") }
+               in_task && /^name *=/ { print $2; exit }' "$toml"
+  done | sort -u > "$ALL"
+elif [ -r "$TASKS" ]; then
+  tr -d '\r' < "$TASKS" | sed 's/#.*//; s/^ *//; s/ *$//' | grep -v '^$' > "$ALL" || true
+else
+  echo "cannot read task list: $TASKS" >&2
+  exit 1
+fi
+grep '^terminal-bench/' "$ALL" > "$TB" || true
+grep '^datacurve/' "$ALL" > "$DS" || true
+[ -s "$TB" ] || [ -s "$DS" ] || { echo "no tasks found in $TASKS" >&2; exit 1; }
+
+common=(--checkpoint "$CHECKPOINT" --harness cursor-cli --provider cursor
+        --run-id "$RUN_ID" --out "$OUT" --timeout "$TIMEOUT")
+
+if [ -s "$TB" ]; then
+  "$FH/run-trials.sh" "${common[@]}" --tasks "$TB" --cmd "$HARBOR_CMD"
+fi
+if [ -s "$DS" ]; then
+  "$FH/run-trials.sh" "${common[@]}" --tasks "$DS"
+fi
+
+# Both adapters install the CLI inside the task container at trial time from Cursor's
+# installer, so nothing pins its version. A run is one configuration only if every trial
+# reports the same version; anything else is two harness versions in one row.
+versions=$(find "$OUT/$RUN_ID/trials" -name '*.json' -size -8M 2>/dev/null \
+  | xargs -r jq -r '.. | objects | select(has("agent_info")) | .agent_info.version? // empty' 2>/dev/null \
+  | sort -u)
+case "$(printf '%s\n' "$versions" | grep -c .)" in
+  0) echo "warning: no agent_info.version found in the collected jobs; record the CLI version by hand" >&2 ;;
+  1) echo "cursor-agent version across all trials: $versions" >&2 ;;
+  *) echo "warning: more than one cursor-agent version in this run; it is not one configuration:" >&2
+     printf '  %s\n' $versions >&2 ;;
+esac


### PR DESCRIPTION
## Summary

Follows up #4 now that #1 has landed. Adds a Cursor CLI profile in the style of #2, but much smaller, because Harbor and Pier both already ship a `cursor-cli` adapter: there is no agent to register and no install step to replace.

- `cursor` provider preset in `providers.sh`: Cursor's own `kimi-k3` model slug, `CURSOR_API_KEY` as the secret, injected on `api2.cursor.sh`. Marked as pairing only with `--harness cursor-cli`.
- `run-cursor-cli.sh`: thin wrapper over `run-trials.sh`. Hands Kimi K3 list prices ($3 / $0.30 cached / $15, plus an optional Cursor Token Rate) to Harbor's adapter through its `pricing` kwarg, since Harbor has no built-in rate for `kimi-k3`; splits the 21 Terminal-Bench and 9 DeepSWE tasks so each suite keeps its runner template under one run id; and reports the set of `cursor-agent` versions seen across trials, warning when there is more than one.
- `provision-golden-checkpoint.sh`: accepts `--harness-version` in place of `--repo`/`--commit` for a harness the runner installs itself. `--repo` and `--commit` are still required as a pair when given. Manifest gains `harness_version`; the report prints it.
- `cursor-cli.md`: the profile. Where the row deviates from the baselines, a smoke test that settles each open point from #4 before a full sweep, and what the profile deliberately does not do.
- Pointers in `README.md`, `SKILL.md`, and `reference.md`.

## What changed since #4 was written

- Cached-token visibility (#4, point 2) is answerable at the wire: both adapters parse a `usage` object (`inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`) from the CLI's `stream-json` result event into token totals and cache-hit rate. Cursor's public output-format reference does not list `usage`, so the smoke test checks for it rather than assuming it.
- Both adapters install `cursor-agent` inside the task container at trial time from Cursor's installer, so nothing pins the version. The wrapper reads `agent_info.version` back from every trial and refuses to call a mixed run one configuration. A checkpointed bundle in the style of #2 is the add-when if the installer drifts within a run.

## Caveats the row lands with

- Provider: model calls go through Cursor's backend to Cursor's inference partner for Kimi K3 (Moonshot per its pricing page). Same weights, so pass rate is comparable; `build-report.mjs` flags the provider as non-baseline automatically. Cursor's custom-key setting is documented for chat only, not the CLI.
- Credential injection: the stub is swapped into the `Authorization` header on `api2.cursor.sh`. Whether the CLI authenticates with that header shape against that host is undocumented; the smoke test's first successful turn is the proof, and the profile names the fallback if it is not.
- Cost: Pier's `cursor-cli` adapter has no pricing override and its LiteLLM lookup has no `kimi-k3` entry, so the 9 DeepSWE trials carry token counts but an empty cost. The profile says to report the Terminal-Bench-only figure or state the join method, never to estimate silently.

## Validation

- `bash -n skills/frontierharness-eval/scripts/*.sh`
- `--print-command` renders the Harbor template with and without a token rate; a non-numeric rate exits 2
- `provision-golden-checkpoint.sh` exits 2 with neither pin, and with `--repo` alone; `--provider cursor --harness-version …` resolves and stops at Runta auth
- Suite split over `tasks/` yields 21 `terminal-bench` and 9 `datacurve`; the version-uniqueness check flags two versions on synthetic job files
- Existing `run-trials.sh` is untouched

I did not run a real Runta or Cursor trial from this environment: no Runta credentials here. This PR adds the workflow, not result claims, and the smoke test in `cursor-cli.md` is written to establish the three unverified points above before anyone spends a full sweep.

## Overlap with #2

#2 also relaxes `--repo`/`--commit` and adds `--harness-version` and a report row. The change here is the minimal form of the same idea. If #2 lands first, I will rebase onto its flags.

Closes #4
