### PR TITLE
Pin benchmark stack and score harness crashes as failures

### DIFF
--- a/skills/frontierharness-eval/PROMPT.md
+++ b/skills/frontierharness-eval/PROMPT.md
@@ -68,7 +68,8 @@ Do this in order, and stop to show me your findings at each numbered boundary:
 5. Run the published 30-task set with $FH/run-trials.sh, one fresh restore per task, and
    report progress as tasks complete. Re-run any trial that died on infrastructure; if
    it fails on infrastructure twice, mark it infra_invalid rather than scoring it as a
-   task failure.
+   task failure. A harness crash is a failure, not infrastructure. The report ranks
+   against the leaderboard only when all 30 tasks are scoreable.
 
 6. Normalize, chart, and build the report with the three node scripts, then show me
    runs/<run-id>/report/REPORT.md and tell me which reproducibility rules from SKILL.md

--- a/skills/frontierharness-eval/SKILL.md
+++ b/skills/frontierharness-eval/SKILL.md
@@ -99,11 +99,11 @@ What the script does, and why each part matters:
   at 100 GiB so every trial restores with the same capacity as the baselines.
 - **Repo pinned by commit.** The harness is cloned to `/work/harness` at `--commit`.
   A branch name is not reproducible; always pin a SHA.
-- **Benchmark stack.** Installs `uv`, `harbor` for Terminal-Bench, `pier` plus the
-  `deep-swe` task corpus for DeepSWE, and `runta-sdk[harbor]`.
+- **Benchmark stack.** Installs `uv`, Harbor `0.22.0` for Terminal-Bench, `datacurve-pier==0.3.1` plus the `deep-swe` corpus at **v1.1**, and `runta-sdk[harbor]`.
 - **Credential as a secret stub.** The provider key named by `--secret-name` (defaulted
   from `--provider`) is stored with `runta secret set` and injected by the egress proxy,
-  so the real key never lands inside the runtime or inside a checkpoint. Verify with
+  so the real key never lands inside the runtime or inside a checkpoint. The script also
+  allowlists the provider host (and `astral.sh` for verifier uv downloads). Verify with
   `runta exec fh-build -- sh -lc 'test "$FIREWORKS_API_KEY" = runta-secret-stub'`.
 - **Cache warming on sample tasks only.** Docker images for the formal tasks are
   pre-pulled, but the only task ever *executed* before the checkpoint is
@@ -227,7 +227,8 @@ explicitly in the report which ones were relaxed.
 | Identical vCPU, memory, and disk (100 GiB) across all restores | Compute differences show up as time and pass-rate differences |
 | No formal task executed before the checkpoint | Prevents warm-cache bias |
 | Canonical result is the first valid attempt | Matches `benchmark.json` `canonical_selection` |
-| Infra failures marked `infra_invalid`, not `failure` | A crashed runtime is not a harness failure |
+| Infra failures marked `infra_invalid`, not `failure` | A crashed runtime or failed restore is not a harness failure. A harness process crash is a failure and stays in the denominator |
+| One shared golden checkpoint for third-party runs | The published 360 cells used a per-task checkpoint. The skill freezes one checkpoint with every image pre-pulled; say so in the report |
 
 Cost comparability has one caveat worth repeating in every report: baseline costs in
 `results/eval-data.json` reprice first-turn cache reads consistently across harnesses.
@@ -242,11 +243,14 @@ values.
 
 | Field | Definition |
 | --- | --- |
-| `pass_rate` | passes / tasks attempted |
+| `pass_rate` | passes / tasks attempted (infra_invalid excluded) |
+| `expected` | published task count from `benchmark.json` (30) |
+| `completed` | scoreable trials |
+| `comparable` | `completed === expected`; the report ranks only then |
 | `effective_cost_per_pass` | total cost across *all* tasks / passes |
 | `median_cost_per_success` | median per-task cost over successful tasks only |
 | `median_duration_seconds` | median wall-clock over successful tasks only |
-| `cache_hit_rate_typical` | median cache hit rate over successful tasks only |
+| `cache_hit_rate_typical` | median runner-reported cache hit rate over successful tasks; not the baseline's repriced series |
 | `mean_turns` | mean agent turns over successful tasks only |
 
 ## Additional resources

--- a/skills/frontierharness-eval/reference.md
+++ b/skills/frontierharness-eval/reference.md
@@ -57,11 +57,11 @@ the model id recognisably Kimi K3 or the scripts will warn:
   --secret-name MY_GATEWAY_API_KEY
 ```
 
-Whichever provider you pick, set egress to its host so trials stay air-gapped apart from
-the model call:
+Whichever provider you pick, the provision and trial scripts set egress to its host
+plus `astral.sh` (Terminal-Bench verifiers curl uv). Confirm with:
 
 ```bash
-runta egress set fh-build --mode allowlist --allow api.moonshot.ai
+runta egress describe fh-build
 ```
 
 ### Cost comparability
@@ -90,8 +90,10 @@ Placeholders: `{task}`, `{suite}`, `{harness}`, `{model}`, `{jobs}`.
 **Terminal-Bench through Harbor** (`terminal-bench/*`):
 
 ```
-harbor run -d terminal-bench/terminal-bench@4.0.0 --task-id {task} -a {harness} -m {model} --jobs-dir {jobs}
+harbor run -d terminal-bench@2.0 -i {task} -a {harness} -m {model} --jobs-dir {jobs} --extra-docker-compose /work/runta-ca-overlay.yaml -r 2 -y
 ```
+
+`terminal-bench@2.0` is the registry name that holds this benchmark's 21 Terminal-Bench tasks. `terminal-bench/terminal-bench@4.0.0` is a different 66-task corpus that shares none of these ids, so it silently evaluates nothing. Harbor 0.22 selects tasks with `-i`, not the removed `--task-id`.
 
 **DeepSWE through Pier** (`datacurve/*`):
 
@@ -182,11 +184,17 @@ these fields, so any custom runner can produce them directly:
 ```
 
 `status` is one of `success`, `failure`, `timeout`, or `infra_invalid`. Only
-`infra_invalid` is excluded from scoring.
+`infra_invalid` is excluded from scoring. Auto-marked infra is restore failure,
+runtime never becoming ready, or credential-rule failure. A harness crash is a
+`failure` and stays in the denominator. Mark a trial `infra_invalid` by hand only
+after a confirmed platform outage.
 
-Reward extraction scans the collected job directory for the first non-null
-`resolved`, `is_resolved`, `reward`, or `passed` field. If a runner reports success
-differently, the extracted value will be wrong — spot-check the first trial:
+Reward extraction reads **top-level** `resolved`, `is_resolved`, `reward`, or
+`passed` from result-named JSON files first (`result.json`, `results.json`,
+`eval.json`, `verifier.json`), then other JSON files in sorted path order. It
+does not walk nested objects, so a passing unit test cannot mark the trial as
+success. If a runner reports success differently, the extracted value will be
+wrong — spot-check the first trial:
 
 ```bash
 jq . runs/<run-id>/trials/<task>/trial.json

--- a/skills/frontierharness-eval/scripts/providers.sh
+++ b/skills/frontierharness-eval/scripts/providers.sh
@@ -65,3 +65,17 @@ warn_unless_kimi_k3() {
   esac
   echo "warning: --model $1 is not Kimi K3. Every published FrontierHarness result uses Kimi K3, so this score will not be comparable to them." >&2
 }
+
+# Restrict runtime egress to the model host. astral.sh is required because some
+# Terminal-Bench verifiers curl uv; blocking it scores a download failure as a
+# task failure. github.com is intentionally not allowed.
+apply_provider_egress() {
+  local runtime=$1 host=$2
+  [ -n "$runtime" ] && [ -n "$host" ] || return 0
+  if runta egress set "$runtime" --mode allowlist --allow "$host" --allow astral.sh; then
+    return 0
+  fi
+  echo "warning: could not add astral.sh to the egress allowlist on $runtime; trying provider host only" >&2
+  runta egress set "$runtime" --mode allowlist --allow "$host" \
+    || { echo "warning: could not set egress allowlist on $runtime" >&2; return 1; }
+}

--- a/skills/frontierharness-eval/scripts/provision-golden-checkpoint.sh
+++ b/skills/frontierharness-eval/scripts/provision-golden-checkpoint.sh
@@ -22,7 +22,10 @@ PREPULL_TASKS=""
 CPUS=4
 MEMORY=8192
 DISK_GIB=100
-DEEP_SWE_REF="main"
+DEEP_SWE_REF="v1.1"
+HARBOR_PIN="harbor[modal]==0.22.0"
+HARBOR_PIN_FALLBACK="harbor==0.22.0"
+PIER_PIN="datacurve-pier==0.3.1"
 KEEP_RUNTIME=0
 
 usage() {
@@ -52,7 +55,7 @@ Options:
   --disk-size-gib GIB   Writable overlay capacity (default 100). The eval environment
                         needs this much: a harness built from source plus the pre-pulled
                         task images overflows the 16 GiB Runtime Image default.
-  --deep-swe-ref REF    Git ref for the deep-swe corpus (default main)
+  --deep-swe-ref REF    Git ref for the deep-swe corpus (default v1.1, matching benchmark.json)
   --keep-runtime        Do not delete the build runtime after checkpointing
 EOF
 }
@@ -139,6 +142,9 @@ fi
 # The real value stays in the egress proxy; the runtime only ever sees the stub.
 rexec "test \"\$$SECRET_NAME\" = runta-secret-stub" \
   || echo "warning: $SECRET_NAME is not exposed as a stub inside the runtime" >&2
+if [ -n "$PROVIDER_HOST" ]; then
+  apply_provider_egress "$RUNTIME" "$PROVIDER_HOST" || true
+fi
 
 step "3/9 installing base tooling"
 rexec 'set -eu
@@ -162,9 +168,10 @@ rexec "set -eu
 step "5/9 installing Harbor, Pier, and the deep-swe corpus"
 rexec "set -eu
   export PATH=\"\$HOME/.local/bin:\$PATH\"
-  uv tool install --quiet 'harbor[modal]' || uv tool install --quiet harbor
-  uv tool install --quiet git+https://github.com/datacurve-ai/pier
-  uv tool install --quiet --with 'runta-sdk[harbor]' harbor || true
+  uv tool install --quiet --with 'runta-sdk[harbor]' '$HARBOR_PIN' \
+    || uv tool install --quiet --with 'runta-sdk[harbor]' '$HARBOR_PIN_FALLBACK' \
+    || uv tool install --quiet '$HARBOR_PIN_FALLBACK'
+  uv tool install --quiet '$PIER_PIN'
   rm -rf /work/deep-swe
   git clone --quiet https://github.com/datacurve-ai/deep-swe /work/deep-swe
   cd /work/deep-swe && git checkout --quiet '$DEEP_SWE_REF'
@@ -244,6 +251,9 @@ rexec "set -eu
   \"memory_mib\": $MEMORY,
   \"disk_size_gib\": $DISK_GIB,
   \"deep_swe_commit\": \"\$(git -C /work/deep-swe rev-parse HEAD)\",
+  \"deep_swe_ref\": \"$DEEP_SWE_REF\",
+  \"harbor_pin\": \"$HARBOR_PIN_FALLBACK\",
+  \"pier_pin\": \"$PIER_PIN\",
   \"harbor_version\": \"\$(harbor --version 2>&1 | head -1)\",
   \"pier_version\": \"\$(pier --version 2>&1 | head -1)\",
   \"python_version\": \"\$(python3 --version 2>&1)\",

--- a/skills/frontierharness-eval/scripts/run-trials.sh
+++ b/skills/frontierharness-eval/scripts/run-trials.sh
@@ -92,7 +92,14 @@ require_runta_auth || exit 1
 # suite-prefixed id in [task] name, so the set that runs is exactly the set that is
 # defined, with no second list to keep in sync.
 TASK_LIST=$(mktemp)
-trap 'rm -f "$TASK_LIST"' EXIT
+CURRENT_RUNTIME=""
+cleanup() {
+  rm -f "$TASK_LIST"
+  if [ -n "$CURRENT_RUNTIME" ]; then
+    runta rm "$CURRENT_RUNTIME" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
 
 if [ -d "$TASKS" ]; then
   for toml in "$TASKS"/*/task.toml; do
@@ -144,18 +151,41 @@ render() {
     | sed "s|{task}|$2|g; s|{suite}|$3|g; s|{harness}|$HARNESS|g; s|{model}|$MODEL|g; s|{jobs}|$4|g"
 }
 
-# Reward field names differ between Harbor and Pier releases, so probe the common ones
-# across every JSON file the runner produced and take the first usable value.
+# Prefer runner result documents, then the rest, always in sorted path order so
+# extraction is deterministic. Values are read from top-level keys only: walking
+# every nested object used to pick up a passing unit test or trajectory event.
+json_files_ordered() {
+  local dir=$1 all preferred rest
+  [ -d "$dir" ] || return 0
+  all=$(find "$dir" -name '*.json' -size -8M 2>/dev/null | LC_ALL=C sort) || return 0
+  [ -n "$all" ] || return 0
+  preferred=$(printf '%s\n' "$all" | grep -E '/(result|results|eval|verifier)[^/]*\.json$' || true)
+  rest=$(printf '%s\n' "$all" | grep -vE '/(result|results|eval|verifier)[^/]*\.json$' || true)
+  printf '%s\n%s\n' "$preferred" "$rest" | sed '/^$/d'
+}
+
 extract() {
   local dir=$1 filter=$2 file value
-  [ -d "$dir" ] || return 0
   while IFS= read -r file; do
+    [ -n "$file" ] || continue
     value=$(jq -c "$filter" "$file" 2>/dev/null) || continue
     if [ -n "$value" ] && [ "$value" != "null" ]; then
       printf '%s' "$value"
       return 0
     fi
-  done < <(find "$dir" -name '*.json' -size -8M 2>/dev/null)
+  done < <(json_files_ordered "$dir")
+}
+
+runtime_name() {
+  local raw hash
+  raw=$(printf 'fh-%s' "$1" | tr -c 'a-zA-Z0-9-' '-')
+  if [ "${#raw}" -le 52 ]; then
+    printf '%s' "$raw"
+    return
+  fi
+  hash=$(printf '%s' "$1" | openssl dgst -sha256 2>/dev/null | awk '{print $NF}')
+  [ -n "$hash" ] || hash=$(printf '%s' "$1" | cksum | awk '{print $1}')
+  printf 'fh-%s' "$(printf '%s' "$hash" | cut -c1-16)"
 }
 
 total=0
@@ -169,7 +199,7 @@ while IFS= read -r entry || [ -n "$entry" ]; do
   task=${entry#*/}
   slug=$(echo "$entry" | tr '/' '-')
   trial_dir="$RUN_DIR/trials/$slug"
-  runtime="fh-$(printf '%s' "$RUN_ID-$slug" | tr -c 'a-zA-Z0-9-' '-' | cut -c1-48)"
+  runtime=$(runtime_name "$RUN_ID-$slug")
 
   template=${CMD_TEMPLATE:-$(default_cmd "$suite")}
   if [ -z "$template" ]; then
@@ -183,6 +213,7 @@ while IFS= read -r entry || [ -n "$entry" ]; do
   printf '\n=== [%s] restoring %s\n' "$entry" "$CHECKPOINT" >&2
 
   status=success
+  CURRENT_RUNTIME=""
   if ! runta checkpoint restore "$CHECKPOINT" "$runtime" >"$trial_dir/restore.log" 2>&1; then
     echo "restore failed for $entry" >&2
     jq -n --arg id "$entry" --arg t "$task" \
@@ -190,6 +221,7 @@ while IFS= read -r entry || [ -n "$entry" ]; do
       > "$trial_dir/trial.json"
     continue
   fi
+  CURRENT_RUNTIME=$runtime
 
   # `checkpoint restore` returns as soon as the restore is accepted, while the runtime is
   # still provisioning. Until it finishes, exec fails with a 504 and secret rules with
@@ -209,16 +241,29 @@ while IFS= read -r entry || [ -n "$entry" ]; do
         error:"restored runtime never became ready", runtime:$rt}' \
       > "$trial_dir/trial.json"
     runta rm "$runtime" >/dev/null 2>&1 || true
+    CURRENT_RUNTIME=""
     continue
+  fi
+
+  if [ -n "$SECRET_HOST" ]; then
+    apply_provider_egress "$runtime" "$SECRET_HOST" >>"$trial_dir/restore.log" 2>&1 || true
   fi
 
   # Injection rules live on the runtime, not in the checkpoint, so without this the
   # harness sends the stub placeholder to the provider and every turn fails on auth.
   if [ -n "$SECRET_NAME" ] && [ -n "$SECRET_HOST" ]; then
-    runta secret rule set "$runtime" --secret "$SECRET_NAME" --host "$SECRET_HOST" \
+    if ! runta secret rule set "$runtime" --secret "$SECRET_NAME" --host "$SECRET_HOST" \
       --header Authorization --template 'Bearer ${secret}' \
-      >>"$trial_dir/restore.log" 2>&1 \
-      || echo "warning: could not set the credential rule on $runtime" >&2
+      >>"$trial_dir/restore.log" 2>&1; then
+      echo "credential rule failed for $entry" >&2
+      jq -n --arg id "$entry" --arg t "$task" --arg rt "$runtime" \
+        '{id:$id, title:$t, status:"infra_invalid", success:false,
+          error:"credential injection rule failed", runtime:$rt}' \
+        > "$trial_dir/trial.json"
+      runta rm "$runtime" >/dev/null 2>&1 || true
+      CURRENT_RUNTIME=""
+      continue
+    fi
   fi
 
   jobs_dir="/work/jobs/$slug"
@@ -238,31 +283,30 @@ while IFS= read -r entry || [ -n "$entry" ]; do
     || echo "no job artifacts collected for $entry" >&2
   runta cp "$runtime:/work/manifest.json" "$trial_dir/manifest.json" >/dev/null 2>&1 || true
   runta rm "$runtime" >/dev/null 2>&1 || echo "failed to delete runtime $runtime" >&2
+  CURRENT_RUNTIME=""
 
-  reward=$(extract "$trial_dir/jobs" '[.. | objects | (.resolved?, .is_resolved?, .reward?, .passed?)] | map(select(. != null)) | .[0]')
-  cost=$(extract "$trial_dir/jobs" '[.. | objects | (.total_cost_usd?, .total_cost?, .cost_usd?)] | map(select(type == "number")) | .[0]')
-  turns=$(extract "$trial_dir/jobs" '[.. | objects | (.n_steps?, .num_turns?, .steps?)] | map(select(type == "number")) | .[0]')
-  cache=$(extract "$trial_dir/jobs" '[.. | objects | (.cache_hit_rate?, .cache_read_ratio?)] | map(select(type == "number")) | .[0]')
+  reward=$(extract "$trial_dir/jobs" '.resolved // .is_resolved // .reward // .passed // empty')
+  cost=$(extract "$trial_dir/jobs" '.total_cost_usd // .total_cost // .cost_usd // .usage.total_cost_usd | select(type == "number")')
+  turns=$(extract "$trial_dir/jobs" '.n_steps // .num_turns // .turns // .agent_info.n_steps // .agent_info.num_turns | select(type == "number")')
+  cache=$(extract "$trial_dir/jobs" '.cache_hit_rate // .cache_read_ratio | select(type == "number")')
+  exception=$(extract "$trial_dir/jobs" '.exception_info | select(. != null) | tostring')
 
-  # A trial whose retries were all exhausted by harness crashes never measured the
-  # harness, so it must not enter the denominator as a failure. Harbor records the
-  # surviving crash in exception_info.
-  exception=$(extract "$trial_dir/jobs" '[.. | objects | .exception_info? | select(. != null)] | .[0] | tostring')
-
-  case "$reward" in
-    true|1|1.0) success=true ;;
-    *) success=false ;;
-  esac
+  success=false
+  if success=$(jq -n --argjson r "${reward:-null}" '($r == true) or ($r == 1)' 2>/dev/null); then
+    :
+  else
+    success=false
+  fi
   if [ "$exit_code" -eq 124 ]; then
     status=timeout
     success=false
   elif [ "$success" = true ]; then
     status=success
     passed=$((passed + 1))
-  elif [ -n "$exception" ]; then
-    status=infra_invalid
-    success=false
   else
+    # A harness crash is a harness failure, not infrastructure. Restore, auth, and
+    # runtime-not-ready are the only auto infra_invalid paths. Users can still mark
+    # a trial infra_invalid by hand after a confirmed platform outage.
     status=failure
   fi
 


### PR DESCRIPTION
## Summary
- Pin Harbor 0.22.0, Pier 0.3.1, and deep-swe v1.1 so third-party golden checkpoints match the published 360-cell stack.
- Treat harness process crashes as scored failures (not `infra_invalid`), and extract rewards only from top-level result JSON so nested unit-test passes cannot inflate the score.
- Restrict egress to the provider host plus `astral.sh`, fail credential-rule setup as infra, and use Harbor's `terminal-bench@2.0` / `-i` invocation so the 21 Terminal-Bench tasks actually run.

## Test plan
- [x] Dry-run `provision-golden-checkpoint.sh` and confirm Harbor/Pier versions plus `deep_swe_ref: v1.1` land in the checkpoint manifest
- [x] Confirm `runta egress describe` on the build runtime includes the provider host and `astral.sh`
- [x] Run one Terminal-Bench trial and one DeepSWE trial; check `trial.json` reward comes from a result-named JSON file, not a nested test report
- [x] Force a harness crash and confirm status is `failure`, not `infra_invalid`
- [x] Confirm a restore or credential-rule failure is still `infra_invalid` and excluded from the denominator