### PR TITLE
Add graff (Codegraff) evaluation profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ The workflow that produced the table above ships with this repository, so a harn
 
 [`skills/frontierharness-eval/`](skills/frontierharness-eval/) is an agent-neutral skill: point any coding agent that reads `SKILL.md` at it and it will drive the whole run — freezing the golden checkpoint, running every task from an identical fresh restore, scoring the trials, and building the report.
 
+graff has a ready-made profile: Harbor and Pier do not ship a built-in adapter, so [`graff.md`](skills/frontierharness-eval/graff.md) registers a checkpointed Linux binary and two thin custom agents. It does not add a leaderboard row — a comparable score still needs a full Kimi K3 sweep.
+
+```bash
+skills/frontierharness-eval/scripts/run-graff.sh --print-command
+```
+
 ## How to use the skill
 
 ### Let an agent drive it

--- a/skills/frontierharness-eval/SKILL.md
+++ b/skills/frontierharness-eval/SKILL.md
@@ -255,6 +255,7 @@ values.
 
 ## Additional resources
 
+- graff (Codegraff) profile: [graff.md](graff.md)
 - Command reference, runner templates, and troubleshooting: [reference.md](reference.md)
 - Published results and task definitions: `results/eval-data.json`, `tasks/<task>/task.toml`
 - Source evaluation: <https://frontierharness.org/>

--- a/skills/frontierharness-eval/agents/frontierharness_graff.py
+++ b/skills/frontierharness-eval/agents/frontierharness_graff.py
@@ -1,0 +1,126 @@
+"""Harbor adapter for graff (https://github.com/justrach/codegraff).
+
+Uploads the checkpointed binary into the task container and runs a one-shot
+`graff --json --yolo -p` turn. Networked installs are intentionally avoided:
+trial egress does not allow github.com.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from pathlib import Path
+from typing import Any, override
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+HOST_BINARY = "/work/graff/graff"
+REMOTE_BINARY = "/usr/local/bin/graff"
+OUTPUT_FILENAME = "graff.jsonl"
+PROVIDER_ENV_KEYS = (
+    "FIREWORKS_API_KEY",
+    "MOONSHOT_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+
+
+def native_kimi_model(model: str | None) -> str:
+    """Strip Harbor's LiteLLM provider prefix, leaving graff's model id."""
+    if not model:
+        return "accounts/fireworks/models/kimi-k3"
+    for prefix in ("fireworks_ai/", "openrouter/", "moonshot/", "together_ai/", "openai/"):
+        if model.startswith(prefix):
+            return model[len(prefix) :]
+    return model
+
+
+def provider_env() -> dict[str, str]:
+    return {key: os.environ[key] for key in PROVIDER_ENV_KEYS if os.environ.get(key)}
+
+
+def apply_turn_metrics(path: Path, context: AgentContext) -> None:
+    if not path.is_file():
+        return
+    input_tokens = 0
+    cache_tokens = 0
+    cost = 0.0
+    found = False
+    for line in path.read_text(errors="replace").splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") != "turn":
+            continue
+        found = True
+        input_tokens += int(event.get("input_tokens") or 0)
+        cache_tokens += int(event.get("cache_read_tokens") or 0)
+        cost += float(event.get("cost_usd") or 0)
+    if not found:
+        return
+    context.n_input_tokens = input_tokens
+    context.n_cache_tokens = cache_tokens
+    context.cost_usd = cost
+
+
+class Graff(BaseInstalledAgent):
+    """Checkpointed graff binary, one-shot `--json --yolo -p`."""
+
+    _OUTPUT_FILENAME = OUTPUT_FILENAME
+
+    def __init__(self, *args: Any, binary_path: str = HOST_BINARY, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._binary_path = binary_path
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "graff"
+
+    @override
+    def get_version_command(self) -> str | None:
+        return f"{REMOTE_BINARY} --version"
+
+    @override
+    async def install(self, environment: BaseEnvironment) -> None:
+        host = Path(self._binary_path)
+        if not host.is_file():
+            raise FileNotFoundError(
+                f"graff binary not in the golden checkpoint: {host}"
+            )
+        await environment.upload_file(host, REMOTE_BINARY)
+        quoted = shlex.quote(REMOTE_BINARY)
+        await self.exec_as_root(
+            environment,
+            command=f"chmod 0755 {quoted} && {quoted} --version",
+        )
+
+    @override
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        apply_turn_metrics(self.logs_dir / OUTPUT_FILENAME, context)
+
+    @with_prompt_template
+    @override
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        model = native_kimi_model(self.model_name)
+        logs = "/logs/agent"
+        out = f"{logs}/{OUTPUT_FILENAME}"
+        command = (
+            f"mkdir -p {shlex.quote(logs)}; "
+            f"{shlex.quote(REMOTE_BINARY)} --json --yolo "
+            f"--model {shlex.quote(model)} "
+            f"-p {shlex.quote(instruction)} "
+            f"> {shlex.quote(out)}"
+        )
+        await self.exec_as_agent(environment, command=command, env=provider_env())

--- a/skills/frontierharness-eval/agents/frontierharness_graff_pier.py
+++ b/skills/frontierharness-eval/agents/frontierharness_graff_pier.py
@@ -1,0 +1,140 @@
+"""Pier adapter for graff (https://github.com/justrach/codegraff).
+
+Same contract as the Harbor adapter: upload the checkpointed binary, run a
+one-shot `graff --json --yolo -p` turn. Pier's per-agent allowlist is what
+lets the harness reach the provider on DeepSWE `allow_internet = false` tasks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+from pier.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from pier.agents.network import allowlist_from_urls
+from pier.environments.base import BaseEnvironment
+from pier.models.agent.context import AgentContext
+from pier.models.agent.install import AgentInstallSpec, InstallStep
+from pier.models.agent.network import NetworkAllowlist
+
+HOST_BINARY = "/work/graff/graff"
+REMOTE_BINARY = "/usr/local/bin/graff"
+OUTPUT_FILENAME = "graff.jsonl"
+PROVIDER_ENV_KEYS = (
+    "FIREWORKS_API_KEY",
+    "MOONSHOT_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+
+
+def native_kimi_model(model: str | None) -> str:
+    if not model:
+        return "accounts/fireworks/models/kimi-k3"
+    for prefix in ("fireworks_ai/", "openrouter/", "moonshot/", "together_ai/", "openai/"):
+        if model.startswith(prefix):
+            return model[len(prefix) :]
+    return model
+
+
+def provider_env() -> dict[str, str]:
+    return {key: os.environ[key] for key in PROVIDER_ENV_KEYS if os.environ.get(key)}
+
+
+class Graff(BaseInstalledAgent):
+    """Checkpointed graff binary, one-shot `--json --yolo -p`."""
+
+    SUPPORTS_ATIF = False
+    _OUTPUT_FILENAME = OUTPUT_FILENAME
+
+    def __init__(self, *args: Any, binary_path: str = HOST_BINARY, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._binary_path = binary_path
+
+    @staticmethod
+    def name() -> str:
+        return "graff"
+
+    def get_version_command(self) -> str | None:
+        return f"{REMOTE_BINARY} --version"
+
+    def network_allowlist(self) -> NetworkAllowlist:
+        return allowlist_from_urls(
+            [],
+            default_domains=[
+                "api.fireworks.ai",
+                "api.moonshot.ai",
+                "openrouter.ai",
+            ],
+        )
+
+    def install_spec(self) -> AgentInstallSpec:
+        # Real install uploads the checkpointed binary. Pier requires a non-empty
+        # spec; the no-op step is only for the Dockerfile fingerprint.
+        return AgentInstallSpec(
+            agent_name=self.name(),
+            version=self._version,
+            steps=[InstallStep(user="root", run="true")],
+        )
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        host = Path(self._binary_path)
+        if not host.is_file():
+            raise FileNotFoundError(
+                f"graff binary not in the golden checkpoint: {host}"
+            )
+        await environment.upload_file(host, REMOTE_BINARY)
+        quoted = shlex.quote(REMOTE_BINARY)
+        await self.exec_as_root(
+            environment,
+            command=f"chmod 0755 {quoted} && {quoted} --version",
+        )
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        path = self.logs_dir / OUTPUT_FILENAME
+        if not path.is_file():
+            return
+        input_tokens = 0
+        cache_tokens = 0
+        cost = 0.0
+        found = False
+        for line in path.read_text(errors="replace").splitlines():
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") != "turn":
+                continue
+            found = True
+            input_tokens += int(event.get("input_tokens") or 0)
+            cache_tokens += int(event.get("cache_read_tokens") or 0)
+            cost += float(event.get("cost_usd") or 0)
+        if not found:
+            return
+        context.n_input_tokens = input_tokens
+        context.n_cache_tokens = cache_tokens
+        context.cost_usd = cost
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        model = native_kimi_model(self.model_name)
+        logs = "/logs/agent"
+        out = f"{logs}/{OUTPUT_FILENAME}"
+        command = (
+            f"mkdir -p {shlex.quote(logs)}; "
+            f"{shlex.quote(REMOTE_BINARY)} --json --yolo "
+            f"--model {shlex.quote(model)} "
+            f"-p {shlex.quote(instruction)} "
+            f"> {shlex.quote(out)}"
+        )
+        await self.exec_as_agent(environment, command=command, env=provider_env())

--- a/skills/frontierharness-eval/graff.md
+++ b/skills/frontierharness-eval/graff.md
@@ -1,0 +1,121 @@
+# graff through Harbor and Pier
+
+Use this profile when the harness under evaluation is
+[graff](https://github.com/justrach/codegraff) (`justrach/codegraff`). Harbor and Pier
+do not ship a built-in graff adapter, so this profile registers a thin custom agent
+that uploads a **checkpointed** Linux binary into each task container and runs
+`graff --json --yolo -p`. That keeps setup off GitHub during trials (the skill's
+egress allowlist does not include `github.com`) without changing Harbor or Pier's
+normal configuration, execution, or scoring paths.
+
+| Component | Pin |
+| --- | --- |
+| graff | `v0.0.286` (`68540a541e13dac127c7bb4523f77f736601b186`) |
+| Linux x86_64 tarball SHA-256 | `2098a13099ee9a645a5a535d04fe5fd8f2602181a93542a3e4b1498ba28474d8` |
+| Linux aarch64 tarball SHA-256 | `bdfd1c1cbb365b729c6e2b1d6c6020085c6344f70fb9e1651bb3a84d1f1df4c0` |
+| Harbor | `0.22.0` (skill default) |
+| Pier | `datacurve-pier==0.3.1` (skill default) |
+| Adapters | `frontierharness_graff:Graff` (Harbor), `frontierharness_graff_pier:Graff` (Pier) |
+
+Run these commands from the repository root:
+
+```bash
+FH=skills/frontierharness-eval/scripts
+export RUNTA_TOKEN=rt_...
+export FIREWORKS_API_KEY=...  # or the key selected with --provider
+```
+
+## Provider mapping
+
+graff speaks Fireworks, Moonshot, and OpenRouter natively. The adapter strips Harbor's
+LiteLLM prefix and leaves graff's own model id. Together is not a first-class graff
+provider, so this profile refuses it rather than silently routing through another host.
+
+| `--provider` | LiteLLM route (Harbor/Pier `-m`) | graff `--model` | Key |
+| --- | --- | --- | --- |
+| `fireworks` (default) | `fireworks_ai/accounts/fireworks/models/kimi-k3` | `accounts/fireworks/models/kimi-k3` | `FIREWORKS_API_KEY` |
+| `moonshot` | `moonshot/kimi-k3` | `kimi-k3` | `MOONSHOT_API_KEY` |
+| `openrouter` | `openrouter/moonshotai/kimi-k3` | `moonshotai/kimi-k3` | `OPENROUTER_API_KEY` |
+
+The evaluated model remains Kimi K3. `custom` is not accepted here because a private
+gateway needs a base URL graff does not infer; use `run-trials.sh --cmd` for that.
+
+graff reads the provider key from the environment. Runta injects a stub that the
+egress proxy swaps on the provider host, so the real key never lands in the
+checkpoint or the task container.
+
+## Provision the golden checkpoint
+
+```bash
+$FH/provision-golden-checkpoint.sh \
+  --runtime fh-build-graff \
+  --checkpoint fh-golden-graff-0.0.286 \
+  --harness graff \
+  --provider fireworks \
+  --repo https://github.com/justrach/codegraff \
+  --commit 68540a541e13dac127c7bb4523f77f736601b186 \
+  --cpus 4 --memory 8192 --disk-size-gib 100 \
+  --prepull-tasks tasks \
+  --install-script "$FH/install-graff.sh"
+```
+
+`install-graff.sh` downloads the pinned GitHub-release tarball for the runtime's
+architecture, checks the SHA-256 above, and installs the binary at `/work/graff/graff`.
+The provisioner also copies `skills/frontierharness-eval/agents/*.py` to `/work/` so
+Harbor and Pier can import them with `PYTHONPATH=/work`. Confirm the checkpoint
+manifest records `graff_version` `0.0.286` and a matching `graff_sha256` before
+running trials.
+
+## Smoke-test the integration
+
+Render the commands first. This does not need credentials or a runtime:
+
+```bash
+$FH/run-graff.sh --provider fireworks --print-command
+```
+
+Then run one Terminal-Bench task and one DeepSWE task from a fresh restore before
+spending a full sweep:
+
+```bash
+printf '%s\n' terminal-bench/regex-log datacurve/anko-typed-variable-bindings > tasks-graff-smoke.txt
+
+$FH/run-graff.sh \
+  --checkpoint fh-golden-graff-0.0.286 \
+  --provider fireworks \
+  --run-id graff-0.0.286-smoke \
+  --tasks tasks-graff-smoke.txt
+```
+
+A successful smoke test has `agent_info.name` `graff`, `agent_info.version` containing
+`0.0.286`, a `graff.jsonl` transcript, and a verifier result. A model response without
+a verifier result is not a successful smoke test.
+
+## Run the published task set
+
+```bash
+$FH/run-graff.sh \
+  --checkpoint fh-golden-graff-0.0.286 \
+  --provider fireworks \
+  --run-id "$(date +%Y-%m-%d)-graff-0.0.286"
+```
+
+With no `--tasks`, this is the published 30-task set. `run-graff.sh` delegates restore,
+evidence collection, and retry semantics to `run-trials.sh`, and overrides the two
+suite templates so Harbor and Pier load the custom adapters.
+
+## Result caveat
+
+graff's `--json` `turn` events expose `cost_usd`, `input_tokens`, and
+`cache_read_tokens`. The adapters copy those into Harbor/Pier's agent context when
+present. If a trial's JSONL has no `turn` event, cost fields stay empty — do not
+substitute an estimate. This PR adds the workflow, not a leaderboard row: a comparable
+score still needs a full 30-task sweep on Kimi K3 from a golden checkpoint.
+
+## What this profile deliberately does not do
+
+- It does not install graff from `latest` or build Zig inside the task container.
+- It does not enable `graff login` / subscription OAuth. BYOK only, matching the
+  published Fireworks baselines.
+- It does not run DeepSWE through Harbor. Pier's per-agent allowlist is what lets the
+  harness reach the provider on `allow_internet = false` tasks.

--- a/skills/frontierharness-eval/reference.md
+++ b/skills/frontierharness-eval/reference.md
@@ -116,7 +116,9 @@ DeepSWE tasks go through Pier rather than Harbor.
 
 If a harness is not a built-in agent for either runner, register it as a custom agent in
 the runner's agent registry inside `--install-script`, then pass its registered name as
-`--harness`.
+`--harness`. Suite-specific overrides `--terminal-cmd` and `--datacurve-cmd` on
+`run-trials.sh` win over `--cmd` so a custom Harbor import path does not have to be the
+DeepSWE command too. graff uses that split: see [graff.md](graff.md).
 
 ## Running Harbor with Runta as the environment provider
 

--- a/skills/frontierharness-eval/scripts/install-graff.sh
+++ b/skills/frontierharness-eval/scripts/install-graff.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Install a pinned graff Linux binary into the golden checkpoint.
+# Runs inside the Runta build runtime as /work/install-harness.sh, cwd /work/harness.
+set -euo pipefail
+
+GRAFF_VERSION="${GRAFF_VERSION:-0.0.286}"
+GRAFF_COMMIT="${GRAFF_COMMIT:-68540a541e13dac127c7bb4523f77f736601b186}"
+INSTALL_DIR=/work/graff
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    ARCHIVE="graff-x86_64-linux.tar.gz"
+    SHA256="2098a13099ee9a645a5a535d04fe5fd8f2602181a93542a3e4b1498ba28474d8"
+    ;;
+  aarch64|arm64)
+    ARCHIVE="graff-aarch64-linux.tar.gz"
+    SHA256="bdfd1c1cbb365b729c6e2b1d6c6020085c6344f70fb9e1651bb3a84d1f1df4c0"
+    ;;
+  *)
+    echo "unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+URL="https://github.com/justrach/codegraff/releases/download/v${GRAFF_VERSION}/${ARCHIVE}"
+mkdir -p "$INSTALL_DIR"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "downloading $URL"
+curl -fsSL "$URL" -o "$tmp/$ARCHIVE"
+actual=$(sha256sum "$tmp/$ARCHIVE" | awk '{print $1}')
+if [ "$actual" != "$SHA256" ]; then
+  echo "graff tarball digest mismatch: expected $SHA256 got $actual" >&2
+  exit 1
+fi
+
+tar -xzf "$tmp/$ARCHIVE" -C "$tmp"
+bin=$(find "$tmp" -type f -name graff | head -n 1)
+if [ -z "$bin" ]; then
+  echo "graff binary not found inside $ARCHIVE" >&2
+  find "$tmp" -maxdepth 3 -type f >&2
+  exit 1
+fi
+
+install -m 0755 "$bin" "$INSTALL_DIR/graff"
+mkdir -p "$HOME/.local/bin"
+ln -sfn "$INSTALL_DIR/graff" "$HOME/.local/bin/graff"
+export PATH="$HOME/.local/bin:$PATH"
+
+version_out=$("$INSTALL_DIR/graff" --version 2>&1 || true)
+echo "$version_out"
+case "$version_out" in
+  *"$GRAFF_VERSION"*) ;;
+  *)
+    echo "warning: graff --version did not contain $GRAFF_VERSION" >&2
+    ;;
+esac
+
+printf '%s\n' "$GRAFF_VERSION" > "$INSTALL_DIR/VERSION"
+printf '%s\n' "$GRAFF_COMMIT" > "$INSTALL_DIR/COMMIT"
+printf '%s\n' "$SHA256" > "$INSTALL_DIR/SHA256"
+printf '%s\n' "$ARCHIVE" > "$INSTALL_DIR/ARCHIVE"
+
+# Provisioner writes /work/manifest.json after this script; drop extra pins
+# where it will merge them if present.
+jq -n --arg v "$GRAFF_VERSION" --arg c "$GRAFF_COMMIT" --arg s "$SHA256" \
+   --arg a "$ARCHIVE" \
+   '{graff_version:$v, graff_commit:$c, graff_sha256:$s, graff_archive:$a}' \
+   > /work/harness-extra.json
+
+echo "graff $GRAFF_VERSION installed at $INSTALL_DIR/graff"

--- a/skills/frontierharness-eval/scripts/provision-golden-checkpoint.sh
+++ b/skills/frontierharness-eval/scripts/provision-golden-checkpoint.sh
@@ -181,6 +181,13 @@ if [ -n "$INSTALL_SCRIPT" ]; then
   step "6/9 running harness install script"
   [ -f "$INSTALL_SCRIPT" ] || { echo "install script not found: $INSTALL_SCRIPT" >&2; exit 1; }
   runta cp "$INSTALL_SCRIPT" "$RUNTIME:/work/install-harness.sh"
+  agents_dir="$(cd "$(dirname "$INSTALL_SCRIPT")" && pwd)/../agents"
+  if [ -d "$agents_dir" ]; then
+    for agent in "$agents_dir"/*.py; do
+      [ -f "$agent" ] || continue
+      runta cp "$agent" "$RUNTIME:/work/$(basename "$agent")"
+    done
+  fi
   rexec 'set -eu
     export PATH="$HOME/.local/bin:$PATH"
     chmod +x /work/install-harness.sh
@@ -260,6 +267,10 @@ rexec "set -eu
   \"created_at\": \"\$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
 }
 MANIFEST
+  if [ -f /work/harness-extra.json ]; then
+    jq -s '.[0] * .[1]' /work/manifest.json /work/harness-extra.json > /work/manifest.merged.json
+    mv /work/manifest.merged.json /work/manifest.json
+  fi
   jq . /work/manifest.json"
 
 # runta cp 0.1.21 transfers the file but can still exit non-zero ("unable to create

--- a/skills/frontierharness-eval/scripts/run-graff.sh
+++ b/skills/frontierharness-eval/scripts/run-graff.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Run graff as a custom Harbor/Pier agent against the public task set.
+set -euo pipefail
+
+# shellcheck source=providers.sh
+. "$(cd "$(dirname "$0")" && pwd)/providers.sh"
+
+PROVIDER="fireworks"
+MODEL=""
+CHECKPOINT=""
+RUN_ID=""
+TASKS=""
+OUT="runs"
+TIMEOUT="5400"
+PRINT_COMMAND=0
+
+usage() {
+  cat <<USAGE
+Usage: run-graff.sh --checkpoint NAME --run-id ID [options]
+
+Options:
+  --provider NAME      Kimi K3 provider (default fireworks). One of:
+                       fireworks moonshot openrouter
+  --model ID           Override the provider's Kimi K3 model route
+  --tasks FILE         Suite-prefixed task list (default: published tasks/)
+  --out DIR            Root output directory (default runs)
+  --timeout SEC        Per-task timeout (default 5400)
+  --print-command      Print the rendered Harbor and Pier templates and exit;
+                       no credentials or Runta runtime are required
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --checkpoint) CHECKPOINT=$2; shift 2 ;;
+    --run-id) RUN_ID=$2; shift 2 ;;
+    --tasks) TASKS=$2; shift 2 ;;
+    --provider) PROVIDER=$2; shift 2 ;;
+    --model) MODEL=$2; shift 2 ;;
+    --out) OUT=$2; shift 2 ;;
+    --timeout) TIMEOUT=$2; shift 2 ;;
+    --print-command) PRINT_COMMAND=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if ! resolve_provider "$PROVIDER" || [ "$PROVIDER" = custom ] || [ "$PROVIDER" = together ]; then
+  echo "unsupported --provider $PROVIDER; expected fireworks, moonshot, or openrouter" >&2
+  exit 2
+fi
+MODEL=${MODEL:-$PROVIDER_MODEL}
+warn_unless_kimi_k3 "$MODEL"
+case "$MODEL" in
+  ""|*[!A-Za-z0-9._:/+-]*) echo "invalid --model: $MODEL" >&2; exit 2 ;;
+esac
+case "$TIMEOUT" in
+  ""|*[!0-9]*) echo "invalid --timeout: $TIMEOUT" >&2; exit 2 ;;
+esac
+
+COMMAND_PREFIX="env PYTHONPATH=/work"
+AGENT_ARGS="-a frontierharness_graff:Graff -m {model} --ak binary_path=/work/graff/graff --jobs-dir {jobs} --extra-docker-compose /work/runta-ca-overlay.yaml -r 2 -y"
+TERMINAL_COMMAND="$COMMAND_PREFIX harbor run -d terminal-bench@2.0 -i {task} $AGENT_ARGS"
+DATACURVE_COMMAND="$COMMAND_PREFIX pier run -p /work/deep-swe/tasks/{task} --agent-import-path frontierharness_graff_pier:Graff --model {model} --agent-kwarg binary_path=/work/graff/graff --output-dir {jobs}"
+
+if [ "$PRINT_COMMAND" -eq 1 ]; then
+  printf 'terminal-bench\t%s\n' "$TERMINAL_COMMAND"
+  printf 'datacurve\t%s\n' "$DATACURVE_COMMAND"
+  exit 0
+fi
+
+if [ -z "$CHECKPOINT" ] || [ -z "$RUN_ID" ]; then
+  echo "missing --checkpoint or --run-id" >&2
+  usage >&2
+  exit 2
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+args=(
+  --checkpoint "$CHECKPOINT"
+  --harness graff
+  --provider "$PROVIDER"
+  --model "$MODEL"
+  --run-id "$RUN_ID"
+  --out "$OUT"
+  --timeout "$TIMEOUT"
+  --terminal-cmd "$TERMINAL_COMMAND"
+  --datacurve-cmd "$DATACURVE_COMMAND"
+)
+if [ -n "$TASKS" ]; then
+  args+=(--tasks "$TASKS")
+fi
+exec "$SCRIPT_DIR/run-trials.sh" "${args[@]}"

--- a/skills/frontierharness-eval/scripts/run-trials.sh
+++ b/skills/frontierharness-eval/scripts/run-trials.sh
@@ -16,6 +16,8 @@ RUN_ID=""
 TASKS="tasks"
 OUT="runs"
 CMD_TEMPLATE=""
+TERMINAL_CMD_TEMPLATE=""
+DATACURVE_CMD_TEMPLATE=""
 TIMEOUT=5400
 SECRET_NAME=""
 SECRET_HOST=""
@@ -34,8 +36,12 @@ Usage: run-trials.sh --checkpoint NAME --harness NAME --run-id ID
   --model ID      Override the model route. Must still be Kimi K3; the benchmark does
                   not vary the model. Required with --provider custom.
   --out DIR       Root output directory (default runs)
-  --cmd TEMPLATE  Override the runner command. Placeholders: {task} {suite} {harness}
-                  {model} {jobs}. Default templates are per suite, see reference.md.
+  --cmd TEMPLATE  Override the runner command for every suite. Placeholders: {task}
+                  {suite} {harness} {model} {jobs}. Default templates are per suite.
+  --terminal-cmd TEMPLATE
+                  Override only the Terminal-Bench (Harbor) template. Wins over --cmd.
+  --datacurve-cmd TEMPLATE
+                  Override only the DeepSWE (Pier) template. Wins over --cmd.
   --timeout SEC   Per-task timeout in seconds (default 5400, matching task.toml)
   --secret-name NAME  Provider key to inject on egress. Defaults to the provider preset.
   --secret-host HOST  Host the key is injected for. Defaults to the provider preset.
@@ -56,6 +62,8 @@ while [ $# -gt 0 ]; do
     --tasks) TASKS=$2; shift 2 ;;
     --out) OUT=$2; shift 2 ;;
     --cmd) CMD_TEMPLATE=$2; shift 2 ;;
+    --terminal-cmd) TERMINAL_CMD_TEMPLATE=$2; shift 2 ;;
+    --datacurve-cmd) DATACURVE_CMD_TEMPLATE=$2; shift 2 ;;
     --timeout) TIMEOUT=$2; shift 2 ;;
     --secret-name) SECRET_NAME=$2; shift 2 ;;
     --secret-host) SECRET_HOST=$2; shift 2 ;;
@@ -201,7 +209,11 @@ while IFS= read -r entry || [ -n "$entry" ]; do
   trial_dir="$RUN_DIR/trials/$slug"
   runtime=$(runtime_name "$RUN_ID-$slug")
 
-  template=${CMD_TEMPLATE:-$(default_cmd "$suite")}
+  case "$suite" in
+    terminal-bench) template=${TERMINAL_CMD_TEMPLATE:-${CMD_TEMPLATE:-$(default_cmd "$suite")}} ;;
+    datacurve)      template=${DATACURVE_CMD_TEMPLATE:-${CMD_TEMPLATE:-$(default_cmd "$suite")}} ;;
+    *)              template=${CMD_TEMPLATE:-$(default_cmd "$suite")} ;;
+  esac
   if [ -z "$template" ]; then
     echo "no runner template for suite '$suite'; pass --cmd" >&2
     exit 1

--- a/skills/frontierharness-eval/tests/test-graff.sh
+++ b/skills/frontierharness-eval/tests/test-graff.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Offline checks for the graff evaluation profile. No Runta credentials required.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
+FH="$ROOT/skills/frontierharness-eval/scripts"
+cd "$ROOT"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+bash -n "$FH/install-graff.sh"
+bash -n "$FH/run-graff.sh"
+bash -n "$FH/run-trials.sh"
+bash -n "$FH/provision-golden-checkpoint.sh"
+bash -n "$ROOT/skills/frontierharness-eval/tests/test-graff.sh"
+
+python3 - <<'PY'
+import ast
+from pathlib import Path
+root = Path("skills/frontierharness-eval/agents")
+for name in ("frontierharness_graff.py", "frontierharness_graff_pier.py"):
+    ast.parse((root / name).read_text(), filename=name)
+print("ast.parse ok")
+PY
+
+out=$("$FH/run-graff.sh" --print-command)
+printf '%s\n' "$out" | grep -q 'frontierharness_graff:Graff' \
+  || fail "Harbor template missing frontierharness_graff:Graff"
+printf '%s\n' "$out" | grep -q 'frontierharness_graff_pier:Graff' \
+  || fail "Pier template missing frontierharness_graff_pier:Graff"
+printf '%s\n' "$out" | grep -q 'terminal-bench@2.0' \
+  || fail "Harbor template missing terminal-bench@2.0"
+printf '%s\n' "$out" | grep -q '/work/deep-swe/tasks/{task}' \
+  || fail "Pier template missing deep-swe task path"
+printf '%s\n' "$out" | grep -q 'binary_path=/work/graff/graff' \
+  || fail "templates missing checkpointed binary path"
+
+if "$FH/run-graff.sh" --provider together --print-command >/dev/null 2>&1; then
+  fail "together should be rejected"
+fi
+if "$FH/run-graff.sh" --provider custom --print-command >/dev/null 2>&1; then
+  fail "custom should be rejected"
+fi
+
+"$FH/run-trials.sh" --help | grep -q -- '--terminal-cmd' \
+  || fail "run-trials.sh --help missing --terminal-cmd"
+"$FH/run-trials.sh" --help | grep -q -- '--datacurve-cmd' \
+  || fail "run-trials.sh --help missing --datacurve-cmd"
+
+grep -q '2098a13099ee9a645a5a535d04fe5fd8f2602181a93542a3e4b1498ba28474d8' \
+  "$ROOT/skills/frontierharness-eval/graff.md" \
+  || fail "graff.md missing x86_64 digest"
+grep -q '68540a541e13dac127c7bb4523f77f736601b186' \
+  "$ROOT/skills/frontierharness-eval/graff.md" \
+  || fail "graff.md missing commit pin"
+
+echo "ok"


### PR DESCRIPTION
## What changed

Adds a graff (Codegraff) evaluation profile so the harness can be scored on the same 30 tasks, Runta golden-checkpoint runtime, and Kimi K3 cost accounting as the published baselines.

- `graff.md`: pins, provider mapping, provision/smoke/full-run commands, and the caveats a comparable row has to carry.
- Harbor adapter `frontierharness_graff:Graff` and Pier adapter `frontierharness_graff_pier:Graff`. Each uploads the checkpointed Linux binary into the task container and runs `graff --json --yolo -p`.
- `install-graff.sh`: downloads the pinned GitHub-release tarball, checks SHA-256, installs `/work/graff/graff`.
- `run-graff.sh`: suite-specific Harbor/Pier commands. Together and `custom` are refused.
- `run-trials.sh` gains `--terminal-cmd` / `--datacurve-cmd` so a custom Harbor import path is not also used as the Pier command.
- Provisioner copies `agents/*.py` next to the install script onto `/work/`, and merges `/work/harness-extra.json` into the checkpoint manifest.

## Why

**Problem.** graff is not a built-in Harbor or Pier agent. A per-trial `curl | sh` install needs `github.com`, which the skill's egress allowlist deliberately omits. That would fail every trial at install time and score as a harness failure.

**Approach.** Freeze a SHA-256-pinned `v0.0.286` binary in the golden checkpoint (same moment Harbor/Pier/images are frozen), then `upload_file` it into each task container. One-shot `graff --json --yolo -p` is the unattended path; `--json` `turn` events feed `cost_usd` / token counts when present.

**Constraints.** The model stays Kimi K3. Fireworks / Moonshot / OpenRouter are first-class graff providers; Together is not, so the profile errors instead of rewriting the route. DeepSWE still goes through Pier because Harbor black-holes agent LLM calls on `allow_internet = false` tasks.

**Rejected.** Harbor's generic ACP agent downloading graff per trial (GitHub blocked). Building Zig inside the task container. Harbor-only for all 30 tasks (needs MiniMax's unmerged `--harbor-only`). Claiming a leaderboard row without a Runta sweep.

## Validation

- `skills/frontierharness-eval/tests/test-graff.sh`
- `bash -n` on the new and touched shell scripts
- `ast.parse` on both adapters
- `--print-command` renders Harbor `terminal-bench@2.0` and Pier `deep-swe` templates with the custom import paths

I did not run a real Runta/Kimi K3 task or the full 30-task sweep from this environment: no Runta credentials here. This PR adds the reproducible integration workflow, not benchmark result claims. The smoke test in `graff.md` is what should run before anyone spends a full sweep.

## Overlap

#2 and #6 also add harness profiles and (in #2) suite-specific commands. If either lands first I will rebase the `--terminal-cmd` / `--datacurve-cmd` flags onto whatever form they shipped.
