### PR TITLE
Add mcode 0.3.2 Kimi K3 adapters for Harbor and Pier

### DIFF
--- a/skills/frontierharness-eval/SKILL.md
+++ b/skills/frontierharness-eval/SKILL.md
@@ -255,6 +255,7 @@ values.
 
 ## Additional resources
 
+- MiniMax Code 0.3.2 with Kimi K3, using Harbor for Terminal-Bench and Pier for DeepSWE: [mcode profile](profiles/mcode/README.md)
 - Command reference, runner templates, and troubleshooting: [reference.md](reference.md)
 - Published results and task definitions: `results/eval-data.json`, `tasks/<task>/task.toml`
 - Source evaluation: <https://frontierharness.org/>

--- a/skills/frontierharness-eval/profiles/mcode/README.md
+++ b/skills/frontierharness-eval/profiles/mcode/README.md
@@ -1,0 +1,156 @@
+# MiniMax Code 0.3.2 with Kimi K3
+
+This profile publishes the agent/runner adapters used by the completed candidate in
+[#13](https://github.com/frontier-harness-eval/eval/pull/13). It replaces the 0.2.7,
+all-Harbor proposal in [#2](https://github.com/frontier-harness-eval/eval/pull/2):
+**Terminal-Bench uses Harbor 0.22.0; DeepSWE uses Pier 0.3.1.**
+Follow the [official skill](../../SKILL.md) for checkpoint creation, fresh restores,
+first-valid-attempt selection and reporting. No official script or task is changed here.
+
+## Adaptation boundary
+
+- `frontierharness_mcode.py` subclasses Harbor's built-in MCode agent only to install
+  the archived Node/mcode bundle without task-time package downloads.
+- `mcode_kimi_profile.py` adds K3 model metadata through mcode's normal configuration
+  and reads its final usage event when Harbor has no per-message usage.
+- `pier_mcode.py` and `pier-proxy.cjs` run the same agent through Pier's public
+  interface and authenticated proxy, allowlisted only for `api.moonshot.cn`. The Node
+  preload applies only to the mcode command; tool subprocesses can inherit Pier's
+  HTTP(S) proxy environment. This profile does not change that native behavior.
+- `pier_environment.py` preserves Pier's native log mounts when adding CA/session mounts.
+- `run_task.py` implements the official `--cmd` hook: select the suite runner, supply
+  configuration and expose the native verifier reward for the official extractor.
+  Native results remain intact; absent rewards and usage stay unknown.
+
+Task instructions, images, verifiers, native phase limits, resources and Harbor's mcode
+execution logic are unchanged. The profile uses one native attempt and zero automatic
+retries. It adds no task-specific prompt, extra task tool, answer retry or scoring rule.
+Harbor's existing BYOK behavior disables login-backed web search. X-Ray and prompt
+compression were disabled for the submitted run.
+
+## Pins and K3 settings
+
+| Component | Submitted run |
+| --- | --- |
+| Official eval code | `8f11b130c30bbf76ca1f3edeea70abc773bd8d2c` |
+| MiniMax Code | Official npm release `@minimax-ai/code@0.3.2` |
+| Node / Python | `22.23.2` Linux x86-64 / `3.12.3` |
+| Harbor / Pier / Runta SDK | `0.22.0` / `0.3.1` / `0.2.0` |
+| Pier client proxy dependency | `undici@8.10.2` |
+| Terminal-Bench source | `laude-institute/terminal-bench-2@69671fbaac6d67a7ef0dfec016cc38a64ef7a77c` |
+| DeepSWE source | `datacurve-ai/deep-swe@435ee89ec2f2e2289f33b0da4f992f0b7b7266b9` |
+
+The npm release publishes no source repository or `gitHead`; the eval checkout commit
+is not mcode's source commit. `requirements.txt` pins the runner packages. The archived
+checkpoint manifest records the full Python dependency list, and the archived mcode
+runtime contains its installed npm dependencies. A new package resolution is not
+necessarily identical to the archived environment.
+
+`kimi-k3-model-settings.json` supplies reasoning/tool support, **thinking=max**,
+**1,048,576** context tokens and **131,072** output tokens. Sampling uses mcode/provider
+defaults; no temperature override or separate reasoning-token budget is added.
+The model route is `openai/kimi-k3`, with `openai-completions` and
+`https://api.moonshot.cn/v1`. Configuration contains only `runta-secret-stub`; Runta
+injects the actual key on egress. Other provider routes are outside this profile's scope.
+
+## Reproduction inputs
+
+The [review bundle](https://drive.google.com/file/d/123TBFZFFthLGoUtxW62J3N8SbEdw-lsC/view)
+contains the 30 raw trial archives, results CSV, original preparation/execution scripts,
+frozen official code and checkpoint references. Relevant paths inside the bundle:
+
+| Path | Purpose |
+| --- | --- |
+| `scripts/used/` | Actual preparation, execution and collection code |
+| `scripts/official-frozen/` | Official skill/scripts used for this run |
+| `checkpoint/RESTORE.md` | Checkpoint access and rebuild context |
+| `checkpoint/dependency-inputs/mcode-runtime.tar.gz` | Installed Node + mcode 0.3.2 |
+| `checkpoint/dependency-inputs/undici-8.10.2.tgz` | Pier proxy dependency |
+| `checkpoint/rebuild-records/manifest.json` | Full dependency and runtime metadata |
+
+For the official skill's installation phase, stage these adapters and dependencies
+at the following paths in the clean runtime. The task directories must be the unchanged
+sources at the pins above, selecting the official 21 Terminal-Bench and 9 DeepSWE tasks:
+
+```text
+/work/frontierharness/
+  venv/                         # requirements.txt, Python 3.12
+  terminal-bench/<task>/         # native task sources
+  deep-swe/tasks/<task>/         # native task sources
+  mcode-runtime.tar.gz
+  kimi-k3-model-settings.json
+  official/                     # the six .py/.cjs adapters in this profile
+    undici-8.10.2.tgz
+```
+
+Use the original preparation scripts in the bundle as the record of the executed
+procedure. They pre-pull native task images and cache Pier's unchanged proxy Dockerfile;
+formal tasks must not run before the golden checkpoint. Keep 4 vCPU, 8192 MiB memory
+and 100 GiB disk, and validate each native runner on a separate sample restore.
+A checkpoint reference is not a VM export: another account needs access from Runta
+or must rebuild from these inputs.
+
+The submitted environment also used upstream #11's dependency-download allowlist and
+scoped system-runc repair, plus the pinned DeepSWE source because the `v1.1` Git ref was
+unavailable. Those infrastructure changes and the original detached execution are in
+the bundle, **not reimplemented by this profile**. Unpatched main at the pin above
+still has these infrastructure limitations; adding the agent alone does not fix them.
+Before a new run, use the applicable upstream fixes and confirm the stored egress
+policy on restores. Terminal-Bench package downloads are allowed; Pier's agent proxy
+is limited to `api.moonshot.cn`. Historical baseline network parity is not established.
+
+## Official runner hook and results
+
+Once the checkpoint and infrastructure prerequisites above are ready, the integration
+command for the official `run-trials.sh` is below. Use a new output directory; these
+commands are for a new run, not for overwriting the archived candidate in #13.
+
+Before reporting, check the native verifier records: the official normalizer counts
+timeouts as completed non-passes and does not retain a separate unscored count. For the
+submitted run, its 30 completed attempts mean **27 scored and 3 unscored**, with 23
+passes. Keep that distinction alongside `candidate.json`; do not describe all 30 as
+verifier-scored or the three missing scores as verifier failures. Review #13 against
+the archived per-task summary and native records, rather than replacing its artifacts.
+
+```bash
+FH=skills/frontierharness-eval/scripts
+bash "$FH/run-trials.sh" \
+  --checkpoint YOUR_READY_CHECKPOINT --harness mcode \
+  --provider custom --model openai/kimi-k3 \
+  --secret-name OPENAI_API_KEY --secret-host api.moonshot.cn \
+  --run-id frontierharness-mcode-kimi --out runs --timeout 5400 \
+  --cmd 'env PYTHONPATH=/work/frontierharness/official PATH=/work/frontierharness/venv/bin:/usr/local/bin:/usr/bin:/bin /work/frontierharness/venv/bin/python /work/frontierharness/official/run_task.py --suite {suite} --task {task} --model {model} --jobs {jobs}'
+
+node "$FH/normalize-results.mjs" --run runs/frontierharness-mcode-kimi --label 'MiniMax Code'
+node "$FH/generate-chart.mjs" --run runs/frontierharness-mcode-kimi
+node "$FH/build-report.mjs" --run runs/frontierharness-mcode-kimi
+```
+
+The normalizer requires `<run>/run.json`, not `run-config.json`. Keep each trial's
+native `jobs/`, mcode JSONL, stderr, sessions and verifier files. In-flight requests can
+lack returned usage when cancelled; this adapter does not invent a complete bill.
+
+The official script's **outer 5400-second deadline** includes setup and verification;
+it is distinct from native agent/verifier time limits. In the submitted run,
+`arktype-json-schema-refs-dependencies`, `meriyah-explicit-resource-declarations` and
+`python-statemachine-state-data-scoping` ended with native `CancelledError` before
+verification. These are three unscored outer timeouts, not verifier-confirmed failures.
+The submission remains **23/30 (76.7%)**, with four verifier failures and those three
+unscored attempts; maintainers decide the acceptance policy.
+
+A Runta outage before case 9 required rebuilding and continuing the same run; evaluation
+inputs stayed fixed while system runc changed from 1.4.3 to 1.5.1. Also disclose Moonshot
+CN versus Fireworks, shared versus per-task checkpoints, egress policy and partial usage
+when comparing the candidate with the published baselines.
+
+## Offline checks
+
+With Python 3.12, the pinned Harbor/Pier packages and Node installed:
+
+```bash
+python -m unittest discover -s skills/frontierharness-eval/profiles/mcode -p 'test_*.py'
+git diff --check
+```
+
+The tests use native configuration parsers and local runner doubles. They do not
+create a runtime, call a model, execute a benchmark task or establish a ranking.

--- a/skills/frontierharness-eval/profiles/mcode/frontierharness_mcode.py
+++ b/skills/frontierharness-eval/profiles/mcode/frontierharness_mcode.py
@@ -1,0 +1,48 @@
+"""Harbor's MCode adapter with a checkpointed, offline installation step."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any, override
+
+from harbor.agents.installed.mcode import MCode
+from harbor.environments.base import BaseEnvironment
+
+
+class OfflineMCode(MCode):
+    """Install a prebuilt MCode runtime without giving task setup network access."""
+
+    def __init__(
+        self,
+        *args: Any,
+        bundle_path: str = "/work/mcode-runtime.tar.gz",
+        **kwargs: Any,
+    ) -> None:
+        self._bundle_path = Path(bundle_path)
+        super().__init__(*args, **kwargs)
+
+    @override
+    async def install(self, environment: BaseEnvironment) -> None:
+        if not self._bundle_path.is_file():
+            raise FileNotFoundError(f"MCode runtime bundle not found: {self._bundle_path}")
+        remote_bundle = "/tmp/frontierharness-mcode-runtime.tar.gz"
+        await environment.upload_file(self._bundle_path, remote_bundle)
+        quoted_bundle = shlex.quote(remote_bundle)
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                "command -v tar >/dev/null; "
+                'install_dir="$HOME/.local/mcode"; '
+                'rm -rf "$install_dir"; '
+                'mkdir -p "$install_dir" "$HOME/.nvm"; '
+                f"tar -xzf {quoted_bundle} -C \"$install_dir\"; "
+                "printf '%s\\n' "
+                "'export NVM_DIR=\"$HOME/.nvm\"' "
+                "'export PATH=\"$HOME/.local/mcode/bin:$PATH\"' "
+                '> "$HOME/.nvm/nvm.sh"; '
+                '. "$HOME/.nvm/nvm.sh"; '
+                "node --version; mcode --version"
+            ),
+        )

--- a/skills/frontierharness-eval/profiles/mcode/kimi-k3-model-settings.json
+++ b/skills/frontierharness-eval/profiles/mcode/kimi-k3-model-settings.json
@@ -1,0 +1,27 @@
+{
+  "name": "Kimi K3",
+  "attachment": true,
+  "reasoning": true,
+  "tool_call": true,
+  "temperature": false,
+  "modalities": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "limit": {
+    "context": 1048576,
+    "output": 131072
+  },
+  "thinking": {
+    "effortOptions": [
+      "max"
+    ]
+  },
+  "configuration_source": "manual"
+}

--- a/skills/frontierharness-eval/profiles/mcode/mcode_kimi_profile.py
+++ b/skills/frontierharness-eval/profiles/mcode/mcode_kimi_profile.py
@@ -1,0 +1,81 @@
+"""Apply explicit K3 metadata through mcode's normal YAML configuration."""
+import json
+import shlex
+from pathlib import Path
+
+from frontierharness_mcode import OfflineMCode
+
+
+class ConfiguredMCode(OfflineMCode):
+    """Keep Harbor's execution unchanged and extend only model configuration."""
+
+    def __init__(self, *args, model_profile, **kwargs):
+        self._model_profile = json.loads(Path(model_profile).read_text())
+        allowed = {'name', 'attachment', 'reasoning', 'tool_call', 'temperature',
+                   'modalities', 'limit', 'thinking', 'configuration_source'}
+        if set(self._model_profile) - allowed:
+            raise ValueError('Only model metadata may be configured here')
+        super().__init__(*args, **kwargs)
+        if self.model_name != 'openai/kimi-k3' or self._version != '0.3.2':
+            raise ValueError('This profile was validated only for K3 and mcode 0.3.2')
+        if self._model_profile['limit'] != {
+            'context': self._context_window, 'output': self._max_output_tokens
+        }:
+            raise ValueError('Harbor limits and model profile must agree')
+
+    def populate_context_post_run(self, context):
+        super().populate_context_post_run(context)
+        if context.n_input_tokens is not None:
+            return
+        output = self.logs_dir / self._OUTPUT_FILENAME
+        if not output.exists():
+            return
+        usage = None
+        for line in output.read_text().splitlines():
+            try:
+                event = json.loads(line)
+            except ValueError:
+                continue
+            if isinstance(event, dict) and event.get('type') == 'exec.completed':
+                usage = event.get('result', {}).get('usage')
+        if not isinstance(usage, dict):
+            return
+        keys = ('inputTokens', 'cacheReadTokens', 'outputTokens')
+        if not all(isinstance(usage.get(k), int) and usage[k] >= 0 for k in keys):
+            return
+        context.n_input_tokens = usage['inputTokens'] + usage['cacheReadTokens']
+        context.n_cache_tokens = usage['cacheReadTokens']
+        context.n_output_tokens = usage['outputTokens']
+        context.metadata = {**(context.metadata or {}), 'mcode_usage': usage}
+
+    def _build_model_limits_command(self, provider_key, requested_provider, model_id):
+        limits = super()._build_model_limits_command(provider_key, requested_provider, model_id)
+        # A JSON object is also a valid YAML value. Replace only this model's
+        # generated defaults; retain provider credentials and the rest of config.
+        code = r'''
+const fs = require('node:fs');
+const [file, provider, model, profile] = process.argv.slice(1);
+const lines = fs.readFileSync(file, 'utf8').split('\n');
+const custom = lines.indexOf('custom_provider:');
+if (custom < 0) throw new Error('Missing custom provider configuration');
+let start = -1, providerFound = false;
+for (let i = custom + 1; i < lines.length; i++) {
+  if (lines[i] && !lines[i].startsWith(' ')) break;
+  if (/^  \S/.test(lines[i])) providerFound = lines[i] === `  ${provider}:`;
+  if (providerFound && lines[i] === `      ${model}:`) {
+    if (start >= 0) throw new Error('Ambiguous model configuration');
+    start = i;
+  }
+}
+if (start < 0) throw new Error('Unsupported mcode model configuration layout');
+let end = start + 1;
+while (end < lines.length && (!lines[end].trim() || /^ {7,}\S/.test(lines[end]))) end++;
+const value = JSON.stringify(JSON.parse(profile));
+lines.splice(start, end - start, `      ${model}: ${value}`);
+fs.writeFileSync(`${file}.tmp`, lines.join('\n'));
+fs.renameSync(`${file}.tmp`, file);
+'''
+        args = [str(Path(self._DATA_DIR) / 'config.yaml'), provider_key, model_id,
+                json.dumps(self._model_profile, separators=(',', ':'))]
+        apply = 'node -e ' + shlex.quote(code) + ' ' + shlex.join(args)
+        return limits + ' && ' + apply

--- a/skills/frontierharness-eval/profiles/mcode/pier-proxy.cjs
+++ b/skills/frontierharness-eval/profiles/mcode/pier-proxy.cjs
@@ -1,0 +1,4 @@
+// Keep both of MCode's HTTP clients on Pier's native authenticated proxy.
+const { EnvHttpProxyAgent, setGlobalDispatcher } = require('./pier-network/package');
+if (!process.env.HTTPS_PROXY) throw new Error('Pier agent proxy is missing');
+setGlobalDispatcher(new EnvHttpProxyAgent());

--- a/skills/frontierharness-eval/profiles/mcode/pier_environment.py
+++ b/skills/frontierharness-eval/profiles/mcode/pier_environment.py
@@ -1,0 +1,12 @@
+"""Keep Pier's native evidence mounts alongside the mcode and Runta CA mounts."""
+
+from pier.environments.docker.docker import DockerEnvironment
+
+
+class Environment(DockerEnvironment):
+    def __init__(self, *args, mounts_json=None, **kwargs):
+        # Pier treats supplied mounts as a replacement. Extend its own defaults
+        # so CA/session persistence does not remove official verifier evidence.
+        super().__init__(*args, mounts_json=mounts_json, **kwargs)
+        if any(m.get("target") == "/tmp/harbor-mcode" for m in mounts_json or []):
+            self._mounts_json = self._default_log_mounts() + list(mounts_json)

--- a/skills/frontierharness-eval/profiles/mcode/pier_mcode.py
+++ b/skills/frontierharness-eval/profiles/mcode/pier_mcode.py
@@ -1,0 +1,56 @@
+"""Run Harbor's MCode integration through Pier's public agent interface."""
+
+from pathlib import Path
+
+from pier.agents.base import BaseAgent
+from pier.agents.installed.base import BaseInstalledAgent
+from pier.models.agent.network import NetworkAllowlist
+
+from mcode_kimi_profile import ConfiguredMCode
+
+
+class _PierMCode(ConfiguredMCode):
+    async def install(self, environment):
+        folder = Path(__file__).parent
+        await environment.upload_file(folder / "undici-8.10.2.tgz", "/tmp/pier-undici.tgz")
+        await self.exec_as_agent(environment, command=(
+            "mkdir -p /tmp/harbor-mcode/pier-network && "
+            "tar -xzf /tmp/pier-undici.tgz -C /tmp/harbor-mcode/pier-network"
+        ))
+        await environment.upload_file(folder / "pier-proxy.cjs", "/tmp/harbor-mcode/pier-proxy.cjs")
+        await super().install(environment)
+
+    async def _exec(self, environment, command, **kwargs):
+        # The preload is command-local; tools can still inherit Pier's proxy env.
+        if "mcode exec " in command:
+            command = command.replace("mcode exec ",
+                'node --require /tmp/harbor-mcode/pier-proxy.cjs '
+                '"$HOME/.local/mcode/lib/node_modules/@minimax-ai/code/cli.js" exec ', 1)
+        return await BaseInstalledAgent._exec(self, environment, command, **kwargs)
+
+
+class MCode(BaseAgent):
+    """Leave task execution, resource limits and verification to Pier."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._mcode = _PierMCode(*args, **kwargs)
+
+    @staticmethod
+    def name():
+        return "mcode"
+
+    def version(self):
+        return self._mcode.version()
+
+    def network_allowlist(self):
+        return NetworkAllowlist(domains=["api.moonshot.cn"])
+
+    async def setup(self, environment):
+        await self._mcode.setup(environment)
+
+    async def run(self, instruction, environment, context):
+        try:
+            await self._mcode.run(instruction, environment, context)
+        finally:
+            self._mcode.populate_context_post_run(context)

--- a/skills/frontierharness-eval/profiles/mcode/requirements.txt
+++ b/skills/frontierharness-eval/profiles/mcode/requirements.txt
@@ -1,0 +1,3 @@
+harbor[modal]==0.22.0
+datacurve-pier==0.3.1
+runta-sdk[harbor]==0.2.0

--- a/skills/frontierharness-eval/profiles/mcode/run_task.py
+++ b/skills/frontierharness-eval/profiles/mcode/run_task.py
@@ -1,0 +1,131 @@
+"""Select the official suite runner and supply the MCode connection settings.
+
+This is a --cmd target for the upstream run-trials.sh, whose timeout encloses
+the selected runner. It does not restore runtimes, resume jobs or score results.
+"""
+
+import argparse
+import json
+from pathlib import Path
+import signal
+import subprocess
+import tempfile
+
+
+def configuration(root, suite, task, model, jobs):
+    if suite not in {"terminal-bench", "datacurve"}:
+        raise ValueError("Unknown official task suite")
+    if Path(task).name != task or model != "openai/kimi-k3":
+        raise ValueError("Expected an official task name and the Kimi K3 model")
+    source = "terminal-bench" if suite == "terminal-bench" else "deep-swe/tasks"
+    task_path = root / source / task
+    if not (task_path / "task.toml").is_file():
+        raise FileNotFoundError(task_path / "task.toml")
+    runner = "harbor" if suite == "terminal-bench" else "pier"
+    agent = {
+        "import_path": "mcode_kimi_profile:ConfiguredMCode"
+        if runner == "harbor" else "pier_mcode:MCode",
+        "model_name": model,
+        "env": {
+            "OPENAI_API_KEY": "runta-secret-stub",
+            "OPENAI_BASE_URL": "https://api.moonshot.cn/v1",
+        },
+        "kwargs": {
+            "version": "0.3.2",
+            "bundle_path": str((root / "mcode-runtime.tar.gz").resolve()),
+            "model_profile": str(root / "kimi-k3-model-settings.json"),
+            "api_format": "openai-completions",
+            "context_window": 1048576,
+            "max_output_tokens": 131072,
+        },
+    }
+    ca = "/etc/ssl/certs/runta-ca-bundle.crt"
+    config = {
+        "job_name": task,
+        "jobs_dir": str(jobs),
+        "tasks": [{"path": str(task_path)}],
+        "agents": [agent],
+        "n_concurrent_trials": 1,
+        "n_attempts": 1,
+        "retry": {"max_retries": 0},
+        "environment": {
+            "type": "docker",
+            "delete": True,
+            "mounts": [{
+                "type": "bind",
+                "source": "/etc/ssl/certs/ca-certificates.crt",
+                "target": ca,
+                "read_only": True,
+            }, {
+                "type": "bind",
+                "source": str(jobs / "mcode-data"),
+                "target": "/tmp/harbor-mcode",
+            }],
+            "env": {**{name: ca for name in (
+                "CURL_CA_BUNDLE", "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE",
+                "PIP_CERT", "GIT_SSL_CAINFO", "NODE_EXTRA_CA_CERTS",
+            )}, "UV_NATIVE_TLS": "1"},
+        },
+    }
+    if runner == "pier":
+        config["environment"]["import_path"] = "pier_environment:Environment"
+    return runner, config
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path("/work/frontierharness"))
+    parser.add_argument("--suite", required=True)
+    parser.add_argument("--task", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--jobs", type=Path, required=True)
+    parser.add_argument("--print-config", action="store_true")
+    args = parser.parse_args()
+    runner, config = configuration(
+        args.root, args.suite, args.task, args.model, args.jobs
+    )
+    if args.print_config:
+        print(json.dumps({"runner": runner, "config": config}, indent=2))
+        return
+    if (args.jobs / args.task).exists():
+        raise SystemExit("This task already has a job; preserve its first attempt.")
+    data_dir = args.jobs / "mcode-data"
+    data_dir.mkdir(parents=True, exist_ok=False)
+    data_dir.chmod(0o777)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as stream:
+        json.dump(config, stream)
+        config_path = stream.name
+    try:
+        # GNU timeout signals the whole process group. Keep this parent alive
+        # while the native runner handles that signal and finishes its cleanup.
+        previous = signal.signal(signal.SIGTERM, lambda *_: None)
+        try:
+            result = subprocess.Popen([runner, "run", "--config", config_path])
+            (args.jobs / "native-process.json").write_text(json.dumps({
+                "pid": result.pid, "runner": runner,
+            }) + "\n")
+            result.wait()
+        finally:
+            signal.signal(signal.SIGTERM, previous)
+        records = list((args.jobs / args.task).glob("*/result.json"))
+        if len(records) == 1:
+            native = json.loads(records[0].read_text())
+            rewards = (native.get("verifier_result") or {}).get("rewards") or {}
+            # Upstream run-trials.sh reads top-level rewards. Keep the runner's
+            # original result intact and expose only its official verifier value.
+            record = {
+                "reward": rewards.get("reward"),
+                "native_result": str(records[0]),
+                "exception_info": native.get("exception_info"),
+            }
+            target = args.jobs / "result.json"
+            temporary = target.with_suffix(".tmp")
+            temporary.write_text(json.dumps(record, indent=2) + "\n")
+            temporary.replace(target)
+        raise SystemExit(result.returncode)
+    finally:
+        Path(config_path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/frontierharness-eval/profiles/mcode/test_profile.py
+++ b/skills/frontierharness-eval/profiles/mcode/test_profile.py
@@ -1,0 +1,157 @@
+import asyncio
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from unittest.mock import AsyncMock, Mock
+
+import yaml
+from harbor.models.agent.context import AgentContext
+from harbor.models.job.config import JobConfig as HarborConfig
+from pier.models.job.config import JobConfig as PierConfig
+from pier.models.task.config import EnvironmentConfig
+from pier.models.trial.paths import TrialPaths
+
+from mcode_kimi_profile import ConfiguredMCode
+from pier_environment import Environment
+from pier_mcode import MCode
+from run_task import configuration
+
+PROFILE = Path(__file__).resolve().parent
+REPO = PROFILE.parents[3]
+
+
+class ProfileTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def agent(self, cls=ConfiguredMCode):
+        return cls(logs_dir=self.root, model_name="openai/kimi-k3", version="0.3.2",
+                   model_profile=PROFILE / "kimi-k3-model-settings.json",
+                   context_window=1048576, max_output_tokens=131072)
+
+    def test_all_official_tasks_parse_without_limit_or_resource_overrides(self):
+        counts = {"harbor": 0, "pier": 0}
+        for file in (REPO / "tasks").glob("*/task.toml"):
+            suite, task = tomllib.loads(file.read_text())["task"]["name"].split("/")
+            source = "terminal-bench" if suite == "terminal-bench" else "deep-swe/tasks"
+            target = self.root / source / task / "task.toml"
+            target.parent.mkdir(parents=True)
+            target.write_text(file.read_text())
+            runner, raw = configuration(self.root, suite, task, "openai/kimi-k3", self.root / "jobs")
+            config = (HarborConfig if runner == "harbor" else PierConfig).model_validate(raw)
+            counts[runner] += 1
+            self.assertEqual(config.tasks[0].path, target.parent)
+            self.assertEqual(config.n_attempts, 1)
+            self.assertEqual(config.retry.max_retries, 0)
+            self.assertIsNone(config.agents[0].override_timeout_sec)
+            self.assertIsNone(config.verifier.override_timeout_sec)
+            for key, value in config.environment.model_dump().items():
+                if key.startswith("override_"):
+                    self.assertIsNone(value, key)
+            self.assertEqual(config.agents[0].env["OPENAI_API_KEY"], "runta-secret-stub")
+        self.assertEqual(counts, {"harbor": 21, "pier": 9})
+
+    def test_model_metadata_round_trip_preserves_other_configuration(self):
+        agent = self.agent()
+        agent._DATA_DIR = str(self.root)
+        original = {
+            "defaultModel": "existing",
+            "custom_provider": {
+                "harbor-openai": {
+                    "apiKey": "runta-secret-stub", "baseUrl": "https://api.moonshot.cn/v1",
+                    "models": {"kimi-k3": {"name": "K3"}, "other": {"name": "Keep me"}},
+                },
+                "other-provider": {"models": {"other": {"name": "Unchanged"}}},
+            },
+        }
+        file = self.root / "config.yaml"
+        file.write_text(yaml.safe_dump(original, sort_keys=False))
+        subprocess.run(["bash", "-c", agent._build_model_limits_command(
+            "harbor-openai", "openai", "kimi-k3")], check=True, capture_output=True)
+        expected = json.loads(json.dumps(original))
+        expected["custom_provider"]["harbor-openai"]["models"]["kimi-k3"] = json.loads(
+            (PROFILE / "kimi-k3-model-settings.json").read_text())
+        self.assertEqual(yaml.safe_load(file.read_text()), expected)
+
+    def test_usage_fallback_and_missing_usage(self):
+        agent = self.agent()
+        context = AgentContext()
+        agent.populate_context_post_run(context)
+        self.assertIsNone(context.n_input_tokens)
+        usage = {"inputTokens": 10, "cacheReadTokens": 20, "outputTokens": 30}
+        (self.root / "mcode.jsonl").write_text("[]\n" + json.dumps({
+            "type": "exec.completed", "result": {"usage": usage}}) + "\n")
+        agent.populate_context_post_run(context)
+        self.assertEqual((context.n_input_tokens, context.n_cache_tokens, context.n_output_tokens),
+                         (30, 20, 30))
+
+    def test_pier_preserves_native_evidence_mounts(self):
+        folder = self.root / "environment"
+        folder.mkdir()
+        (folder / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        mounts = [{"type": "bind", "source": str(self.root / "sessions"),
+                   "target": "/tmp/harbor-mcode"}]
+        environment = Environment(
+            environment_dir=folder, environment_name="fixture", session_id="fixture",
+            trial_paths=TrialPaths(trial_dir=self.root / "trial"),
+            task_env_config=EnvironmentConfig(), mounts_json=mounts,
+        )
+        self.assertEqual(environment._mounts_json, environment._default_log_mounts() + mounts)
+
+    def test_pier_proxy_is_scoped_to_agent_execution(self):
+        agent = self.agent(MCode)
+        self.assertEqual(agent.network_allowlist().domains, ["api.moonshot.cn"])
+        environment = Mock()
+        environment.agent_process_env.side_effect = lambda env: {
+            **(env or {}), "HTTPS_PROXY": "http://fixture-proxy:8080"}
+        environment.exec = AsyncMock(return_value=Mock(return_code=0, stdout="", stderr=""))
+        asyncio.run(agent._mcode._exec(environment, "mcode exec 'hello'"))
+        call = environment.exec.call_args.kwargs
+        self.assertIn("node --require /tmp/harbor-mcode/pier-proxy.cjs", call["command"])
+        self.assertEqual(call["env"]["HTTPS_PROXY"], "http://fixture-proxy:8080")
+        asyncio.run(agent._mcode._exec(environment, "mcode --version"))
+        self.assertNotIn("--require", environment.exec.call_args.kwargs["command"])
+
+    def test_runner_keeps_native_rewards_and_unscored_results(self):
+        task = self.root / "deep-swe/tasks/fixture"
+        task.mkdir(parents=True)
+        (task / "task.toml").touch()
+        binary = self.root / "pier"
+        binary.write_text(f"#!{sys.executable}\n" + '''
+import json, os, pathlib, sys
+config = json.load(open(sys.argv[-1]))
+folder = pathlib.Path(config['jobs_dir']) / config['job_name'] / 'trial'
+folder.mkdir(parents=True)
+native = json.loads(os.environ['FIXTURE_RESULT'])
+(folder / 'result.json').write_text(json.dumps(native))
+''')
+        binary.chmod(0o755)
+        for index, reward in enumerate((1, 0, None)):
+            with self.subTest(reward=reward):
+                native = {"verifier_result": {"rewards": {"reward": reward}} if reward is not None else None,
+                          "exception_info": {"exception_type": "CancelledError"} if reward is None else None}
+                jobs = self.root / f"jobs-{index}"
+                command = [sys.executable, str(PROFILE / "run_task.py"), "--root", str(self.root),
+                           "--suite", "datacurve", "--task", "fixture", "--model", "openai/kimi-k3",
+                           "--jobs", str(jobs)]
+                env = {**os.environ, "PATH": f"{self.root}:{os.environ['PATH']}",
+                       "FIXTURE_RESULT": json.dumps(native)}
+                subprocess.run(command, env=env, check=True, capture_output=True)
+                bridge = json.loads((jobs / "result.json").read_text())
+                self.assertEqual(bridge["reward"], reward)
+                self.assertEqual(bridge["exception_info"], native["exception_info"])
+                self.assertEqual(json.loads(Path(bridge["native_result"]).read_text()), native)
+                repeat = subprocess.run(command, env=env, capture_output=True)
+                self.assertNotEqual(repeat.returncode, 0)
+                self.assertIn(b"preserve its first attempt", repeat.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds the mcode 0.3.2 integration used in #13. Supersedes #2.

- Reuses Harbor 0.22.0 for Terminal-Bench and adds a Pier 0.3.1 adapter for DeepSWE.
- Supplies offline installation, Kimi K3 settings (thinking=max, context 1,048,576, output 131,072), and proxy/log mounts.
- Includes version pins and reproduction instructions.

Validation: six offline tests passed with the pinned Harbor/Pier versions.
